### PR TITLE
Add brochure page and update villa buttons styling

### DIFF
--- a/truffle-clone/src/app/api/brochure-images/route.ts
+++ b/truffle-clone/src/app/api/brochure-images/route.ts
@@ -24,6 +24,7 @@ export async function GET() {
       .filter(entry => entry.isFile())
       .map(entry => entry.name)
       .filter(name => name.toLowerCase().endsWith('.webp'))
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }))
       .map(name => ({
         src: `/brochure/${name}`,
         alt: formatAlt(name)

--- a/truffle-clone/src/app/api/brochure-images/route.ts
+++ b/truffle-clone/src/app/api/brochure-images/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const BROCHURE_DIR = path.join(process.cwd(), 'public', 'brochure')
+
+const formatAlt = (fileName: string): string => {
+  const nameWithoutExtension = fileName.replace(/\.[^.]+$/u, '')
+  return nameWithoutExtension
+    .replace(/[-_]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .replace(/\b\w/gu, match => match.toUpperCase())
+}
+
+export async function GET() {
+  try {
+    if (!fs.existsSync(BROCHURE_DIR)) {
+      return NextResponse.json({ images: [] })
+    }
+
+    const entries = fs.readdirSync(BROCHURE_DIR, { withFileTypes: true })
+    const images = entries
+      .filter(entry => entry.isFile())
+      .map(entry => entry.name)
+      .filter(name => name.toLowerCase().endsWith('.webp'))
+      .map(name => ({
+        src: `/brochure/${name}`,
+        alt: formatAlt(name)
+      }))
+
+    return NextResponse.json({ images })
+  } catch (error) {
+    console.error('Failed to load brochure images', error)
+    return NextResponse.json({ images: [], error: 'Failed to load brochure images.' }, { status: 500 })
+  }
+}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -106,7 +106,7 @@ export default function BrochurePage() {
     }
 
     return (
-      <div className="flex flex-col border-t border-b border-[#b48828]/20">
+      <div className="flex flex-col border border-[#b48828]/20 rounded-2xl overflow-hidden">
         {resolvedImages.map(image => (
           <img
             key={image.src}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -135,32 +135,6 @@ export default function BrochurePage() {
           <main className="w-full overflow-hidden" style={{ margin: 0, padding: 0 }}>
             <section className="bg-[#ede5d9]/25 pt-6 sm:pt-8 lg:pt-12 pb-12 sm:pb-16 lg:pb-20">
               <div className="max-w-6xl mx-auto px-4 sm:px-6">
-                <header className="text-center max-w-3xl mx-auto">
-                  <div className="inline-flex items-center justify-center gap-2 text-[#b48828] font-medium mb-4">
-                    <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
-                      <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z" />
-                    </svg>
-                    <span>Brochure Collection</span>
-                  </div>
-                  <h1 className="text-3xl md:text-5xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
-                    <span className="relative inline-block">
-                      <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm" />
-                      <span className="relative bg-gradient-to-r from-[#264f28] to-[#2d5a30] bg-clip-text text-transparent font-medium">
-                        Luxury Brochure Experience
-                      </span>
-                    </span>
-                  </h1>
-                  <p className="mt-6 text-[#264f28]/70 leading-relaxed text-base sm:text-lg">
-                    Explore marketing-ready visuals crafted for discerning investors. Upload new assets and this gallery will update automatically to showcase your latest brochure imagery in full fidelity.
-                  </p>
-                </header>
-
-                {errorMessage && (
-                  <div className="mt-8 rounded-2xl border border-red-300 bg-red-50/80 px-4 py-3 text-red-700 text-sm">
-                    {errorMessage}
-                  </div>
-                )}
-
                 {galleryContent}
               </div>
             </section>

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -56,11 +56,11 @@ const FALLBACK_IMAGES: BrochureImage[] = [
   'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Ffc3f04c20d794de88bcaeafd2be9d113?format=webp&width=800',
   'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F8ed078e4b5cb4b5b8910954142fc7fd4?format=webp&width=800',
   'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fc4171d0ac7614f06b2d32c027a0a18a1?format=webp&width=800'
-].map(url => {
+].map((url, index) => {
   const cleanedUrl = removeWidthQuery(url)
   return {
     src: cleanedUrl,
-    alt: deriveAltFromPath(cleanedUrl)
+    alt: `Brochure Page ${index + 1}`
   }
 })
 

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Navigation from '@/components/Navigation'
+import PageTransition from '@/components/PageTransition'
+import LoadingAnimation from '@/components/LoadingAnimation'
+import MouseParticles from '@/components/MouseParticles'
+import ContactFooter from '@/components/ContactFooter'
+
+interface BrochureImage {
+  src: string
+  alt: string
+}
+
+export default function BrochurePage() {
+  const [isLoadingComplete, setIsLoadingComplete] = useState(false)
+  const [isFetchingImages, setIsFetchingImages] = useState(true)
+  const [images, setImages] = useState<BrochureImage[]>([])
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const loadImages = async () => {
+      try {
+        const response = await fetch('/api/brochure-images', { signal: controller.signal })
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`)
+        }
+
+        const payload = (await response.json()) as { images?: BrochureImage[] }
+        setImages(Array.isArray(payload.images) ? payload.images : [])
+        setErrorMessage(null)
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          setErrorMessage('Unable to load brochure assets right now. Please refresh or try again later.')
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsFetchingImages(false)
+        }
+      }
+    }
+
+    loadImages().catch(() => {
+      setErrorMessage('Unable to load brochure assets right now. Please refresh or try again later.')
+      setIsFetchingImages(false)
+    })
+
+    return () => {
+      controller.abort()
+    }
+  }, [])
+
+  const galleryContent = useMemo(() => {
+    if (isFetchingImages) {
+      return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={`brochure-skeleton-${index}`}
+              className="h-48 sm:h-56 lg:h-64 rounded-2xl bg-[#264f28]/10 animate-pulse"
+            />
+          ))}
+        </div>
+      )
+    }
+
+    if (images.length === 0) {
+      return (
+        <div className="max-w-3xl mx-auto text-center mt-10 bg-white/60 border border-[#b48828]/20 rounded-2xl px-6 py-10">
+          <h2 className="text-2xl font-semibold text-[#264f28] mb-3">Brochure gallery is empty</h2>
+          <p className="text-[#264f28]/70 leading-relaxed">
+            Upload .webp files into <code className="bg-[#b48828]/10 px-2 py-1 rounded">public/brochure</code> and refresh this page to see your brochure collection automatically.
+          </p>
+        </div>
+      )
+    }
+
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+        {images.map(image => (
+          <figure
+            key={image.src}
+            className="group relative overflow-hidden rounded-2xl border border-[#b48828]/20 bg-white/80 backdrop-blur-sm shadow-lg"
+          >
+            <img
+              src={image.src}
+              alt={image.alt}
+              className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
+              loading="lazy"
+            />
+            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent text-white px-4 py-3 text-sm font-medium">
+              {image.alt}
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    )
+  }, [images, isFetchingImages])
+
+  return (
+    <div className="antialiased" style={{ margin: 0, padding: 0 }}>
+      {!isLoadingComplete && (
+        <LoadingAnimation onLoadingComplete={() => setIsLoadingComplete(true)} />
+      )}
+
+      <div className={`transition-opacity duration-500 ${isLoadingComplete ? 'opacity-100' : 'opacity-0'}`} style={{ height: 'auto', minHeight: 'auto' }}>
+        <MouseParticles />
+        <Navigation />
+        <PageTransition>
+          <main className="w-full overflow-hidden" style={{ margin: 0, padding: 0 }}>
+            <section className="bg-[#ede5d9]/25 pt-6 sm:pt-8 lg:pt-12 pb-12 sm:pb-16 lg:pb-20">
+              <div className="max-w-6xl mx-auto px-4 sm:px-6">
+                <header className="text-center max-w-3xl mx-auto">
+                  <div className="inline-flex items-center justify-center gap-2 text-[#b48828] font-medium mb-4">
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z" />
+                    </svg>
+                    <span>Brochure Collection</span>
+                  </div>
+                  <h1 className="text-3xl md:text-5xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
+                    <span className="relative inline-block">
+                      <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm" />
+                      <span className="relative bg-gradient-to-r from-[#264f28] to-[#2d5a30] bg-clip-text text-transparent font-medium">
+                        Luxury Brochure Experience
+                      </span>
+                    </span>
+                  </h1>
+                  <p className="mt-6 text-[#264f28]/70 leading-relaxed text-base sm:text-lg">
+                    Explore marketing-ready visuals crafted for discerning investors. Upload new assets and this gallery will update automatically to showcase your latest brochure imagery in full fidelity.
+                  </p>
+                </header>
+
+                {errorMessage && (
+                  <div className="mt-8 rounded-2xl border border-red-300 bg-red-50/80 px-4 py-3 text-red-700 text-sm">
+                    {errorMessage}
+                  </div>
+                )}
+
+                {galleryContent}
+              </div>
+            </section>
+            <ContactFooter />
+          </main>
+        </PageTransition>
+      </div>
+    </div>
+  )
+}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -14,24 +14,6 @@ interface BrochureImage {
 
 const removeWidthQuery = (url: string): string => url.replace(/&width=\d+/u, '')
 
-const deriveAltFromPath = (value: string): string => {
-  const cleaned = value
-    .replace(/\?.*$/u, '')
-    .split('/')
-    .pop()
-
-  if (!cleaned) {
-    return 'Brochure Image'
-  }
-
-  return cleaned
-    .replace(/\.[^.]+$/u, '')
-    .replace(/[-_]+/gu, ' ')
-    .replace(/\s+/gu, ' ')
-    .trim()
-    .replace(/\b\w/gu, match => match.toUpperCase())
-}
-
 const FALLBACK_IMAGES: BrochureImage[] = [
   'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F3a964a2b72a94a3899fa444eaddd254a?format=webp&width=800',
   'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fd79e433943024a1382ca0858218c6bbf?format=webp&width=800',

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -94,7 +94,7 @@ export default function BrochurePage() {
   const galleryContent = useMemo(() => {
     if (isFetchingImages) {
       return (
-        <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30">
+        <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30 mb-6 sm:mb-8">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={`brochure-skeleton-${index}`}
@@ -106,7 +106,7 @@ export default function BrochurePage() {
     }
 
     return (
-      <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30">
+      <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30 mb-6 sm:mb-8">
         {resolvedImages.map(image => (
           <img
             key={image.src}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -131,7 +131,7 @@ export default function BrochurePage() {
         <Navigation />
         <PageTransition>
           <main className="w-full overflow-hidden" style={{ margin: 0, padding: 0 }}>
-            <section className="bg-[#ede5d9]/25 pt-0 sm:pt-0 lg:pt-0 pb-12 sm:pb-16 lg:pb-20">
+            <section className="bg-[#ede5d9]/25 pt-0 sm:pt-0 lg:pt-0 pb-8 sm:pb-10 lg:pb-12">
               <div className="max-w-6xl mx-auto px-4 sm:px-6">
                 {galleryContent}
               </div>

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -94,7 +94,7 @@ export default function BrochurePage() {
   const galleryContent = useMemo(() => {
     if (isFetchingImages) {
       return (
-        <div className="flex flex-col border-t border-b border-[#b48828]/20">
+        <div className="flex flex-col border border-[#b48828]/20 rounded-2xl overflow-hidden">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={`brochure-skeleton-${index}`}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -12,6 +12,58 @@ interface BrochureImage {
   alt: string
 }
 
+const removeWidthQuery = (url: string): string => url.replace(/&width=\d+/u, '')
+
+const deriveAltFromPath = (value: string): string => {
+  const cleaned = value
+    .replace(/\?.*$/u, '')
+    .split('/')
+    .pop()
+
+  if (!cleaned) {
+    return 'Brochure Image'
+  }
+
+  return cleaned
+    .replace(/\.[^.]+$/u, '')
+    .replace(/[-_]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .replace(/\b\w/gu, match => match.toUpperCase())
+}
+
+const FALLBACK_IMAGES: BrochureImage[] = [
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F3a964a2b72a94a3899fa444eaddd254a?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fd79e433943024a1382ca0858218c6bbf?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Faf59ca04394e445b8aae2f7089f4dc37?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fb32de40fc1b54393b2aae50c545dc975?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F07db7127f85249d1a543b3a561e63ace?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F05b9b8dcab944b7ab46515d8562352e4?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F0d3b33d6ad8943f5aeb1fc27d27ca103?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Ffd1b5c27aea94918a779f9915bc9f52a?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F492e9aaf524a4cbb9512c62199258efb?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fe5f9ab2e7fd24d32b684933c677c4d9d?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F6dcbd13430e1492eae4c3f04d9ecb818?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Ff916b93693e149bcad99d86cdaa88f9e?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Faeaea1c858504ece9ee54ad3c5dfc6e0?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F897b11e2e9354328afe22e47e4e703c4?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Ff40216105f7340d590c2b2752c063e98?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F3ca55f3b39bc4de499871b4a8f16f7b6?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fae4763bca63a4230bb8ea0e4f5a423cc?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F3867eac59d634329b0ef455431e266d2?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fee3f37e7d3b04e838b2f0905b9083725?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F34f853a90ea34379a91a93d40545df06?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Ffc3f04c20d794de88bcaeafd2be9d113?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F8ed078e4b5cb4b5b8910954142fc7fd4?format=webp&width=800',
+  'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fc4171d0ac7614f06b2d32c027a0a18a1?format=webp&width=800'
+].map(url => {
+  const cleanedUrl = removeWidthQuery(url)
+  return {
+    src: cleanedUrl,
+    alt: deriveAltFromPath(cleanedUrl)
+  }
+})
+
 export default function BrochurePage() {
   const [isLoadingComplete, setIsLoadingComplete] = useState(false)
   const [isFetchingImages, setIsFetchingImages] = useState(true)
@@ -52,52 +104,41 @@ export default function BrochurePage() {
     }
   }, [])
 
+  const resolvedImages = useMemo(() => {
+    if (images.length > 0) {
+      return [...images].sort((a, b) => a.src.localeCompare(b.src, undefined, { numeric: true, sensitivity: 'base' }))
+    }
+    return [...FALLBACK_IMAGES]
+  }, [images])
+
   const galleryContent = useMemo(() => {
     if (isFetchingImages) {
       return (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+        <div className="flex flex-col mt-8">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={`brochure-skeleton-${index}`}
-              className="h-48 sm:h-56 lg:h-64 rounded-2xl bg-[#264f28]/10 animate-pulse"
+              className="w-full aspect-[3/2] bg-[#264f28]/10 animate-pulse"
             />
           ))}
         </div>
       )
     }
 
-    if (images.length === 0) {
-      return (
-        <div className="max-w-3xl mx-auto text-center mt-10 bg-white/60 border border-[#b48828]/20 rounded-2xl px-6 py-10">
-          <h2 className="text-2xl font-semibold text-[#264f28] mb-3">Brochure gallery is empty</h2>
-          <p className="text-[#264f28]/70 leading-relaxed">
-            Upload .webp files into <code className="bg-[#b48828]/10 px-2 py-1 rounded">public/brochure</code> and refresh this page to see your brochure collection automatically.
-          </p>
-        </div>
-      )
-    }
-
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
-        {images.map(image => (
-          <figure
+      <div className="flex flex-col mt-8">
+        {resolvedImages.map(image => (
+          <img
             key={image.src}
-            className="group relative overflow-hidden rounded-2xl border border-[#b48828]/20 bg-white/80 backdrop-blur-sm shadow-lg"
-          >
-            <img
-              src={image.src}
-              alt={image.alt}
-              className="w-full h-64 object-cover transition-transform duration-500 group-hover:scale-105"
-              loading="lazy"
-            />
-            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent text-white px-4 py-3 text-sm font-medium">
-              {image.alt}
-            </figcaption>
-          </figure>
+            src={image.src}
+            alt={image.alt}
+            className="w-full h-auto block"
+            loading="lazy"
+          />
         ))}
       </div>
     )
-  }, [images, isFetchingImages])
+  }, [isFetchingImages, resolvedImages])
 
   return (
     <div className="antialiased" style={{ margin: 0, padding: 0 }}>

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -94,7 +94,7 @@ export default function BrochurePage() {
   const galleryContent = useMemo(() => {
     if (isFetchingImages) {
       return (
-        <div className="flex flex-col mt-8">
+        <div className="flex flex-col border-t border-b border-[#b48828]/20">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={`brochure-skeleton-${index}`}
@@ -106,7 +106,7 @@ export default function BrochurePage() {
     }
 
     return (
-      <div className="flex flex-col mt-8">
+      <div className="flex flex-col border-t border-b border-[#b48828]/20">
         {resolvedImages.map(image => (
           <img
             key={image.src}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -94,7 +94,7 @@ export default function BrochurePage() {
   const galleryContent = useMemo(() => {
     if (isFetchingImages) {
       return (
-        <div className="flex flex-col border border-[#b48828]/20 rounded-2xl overflow-hidden">
+        <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={`brochure-skeleton-${index}`}
@@ -106,7 +106,7 @@ export default function BrochurePage() {
     }
 
     return (
-      <div className="flex flex-col border border-[#b48828]/20 rounded-2xl overflow-hidden">
+      <div className="flex flex-col rounded-3xl overflow-hidden border-8 border-[#b48828]/30">
         {resolvedImages.map(image => (
           <img
             key={image.src}

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -131,7 +131,7 @@ export default function BrochurePage() {
         <Navigation />
         <PageTransition>
           <main className="w-full overflow-hidden" style={{ margin: 0, padding: 0 }}>
-            <section className="bg-[#ede5d9]/25 pt-6 sm:pt-8 lg:pt-12 pb-12 sm:pb-16 lg:pb-20">
+            <section className="bg-[#ede5d9]/25 pt-0 sm:pt-0 lg:pt-0 pb-12 sm:pb-16 lg:pb-20">
               <div className="max-w-6xl mx-auto px-4 sm:px-6">
                 {galleryContent}
               </div>

--- a/truffle-clone/src/app/brochure/page.tsx
+++ b/truffle-clone/src/app/brochure/page.tsx
@@ -50,7 +50,6 @@ export default function BrochurePage() {
   const [isLoadingComplete, setIsLoadingComplete] = useState(false)
   const [isFetchingImages, setIsFetchingImages] = useState(true)
   const [images, setImages] = useState<BrochureImage[]>([])
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -64,10 +63,9 @@ export default function BrochurePage() {
 
         const payload = (await response.json()) as { images?: BrochureImage[] }
         setImages(Array.isArray(payload.images) ? payload.images : [])
-        setErrorMessage(null)
       } catch (error) {
         if ((error as Error).name !== 'AbortError') {
-          setErrorMessage('Unable to load brochure assets right now. Please refresh or try again later.')
+          console.error('Unable to load brochure assets', error)
         }
       } finally {
         if (!controller.signal.aborted) {
@@ -76,8 +74,8 @@ export default function BrochurePage() {
       }
     }
 
-    loadImages().catch(() => {
-      setErrorMessage('Unable to load brochure assets right now. Please refresh or try again later.')
+    loadImages().catch(error => {
+      console.error('Unable to load brochure assets', error)
       setIsFetchingImages(false)
     })
 

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -147,7 +147,7 @@ export default function MapPage() {
                   />
                   <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/10 backdrop-blur-sm">
                     <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2Fc9f8537acf3a48f48f52d3615f3a74f5?format=webp&width=800"
+                      src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F2ab8e8c603ef4f25996b3b87dfc135eb?format=webp&width=800"
                       alt="Marnfah Pool Villas location map overview"
                       className="w-full h-auto object-contain transform scale-[1.009]"
                       style={{ transformOrigin: 'center left' }}

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -76,6 +76,33 @@ export default function MapPage() {
   const [mapAdjacentHighlight, ...secondaryHighlights] = otherHighlights
   const isSingleSecondaryHighlight = secondaryHighlights.length === 1
 
+  const staticMapCard = (
+    <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/10 backdrop-blur-sm">
+      <img
+        src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F2ab8e8c603ef4f25996b3b87dfc135eb?format=webp"
+        alt="Marnfah Pool Villas location map overview"
+        className="w-full h-auto object-contain transform scale-[1.009]"
+        style={{ transformOrigin: 'center left' }}
+      />
+    </div>
+  )
+
+  const googleMapCard = (
+    <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/30 backdrop-blur-sm aspect-[1980/1488]">
+      <iframe
+        src="https://maps.google.com/maps?q=Pattaya%20Thailand&z=12&output=embed"
+        title="Pattaya Map"
+        className="absolute inset-0 w-full h-full"
+        loading="lazy"
+        allowFullScreen
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+      <div className="absolute top-4 right-4 bg-white/80 backdrop-blur-md rounded-xl px-4 py-2 text-[#264f28] shadow-lg">
+        <span className="text-sm font-medium">12.8°N, 100.9°E</span>
+      </div>
+    </div>
+  )
+
   return (
     <div className="antialiased min-h-screen">
       {!isLoadingComplete && (

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -116,27 +116,7 @@ export default function MapPage() {
                   </div>
                 )}
 
-                <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/30 backdrop-blur-sm mt-6 sm:mt-8 mb-8 sm:mb-10 aspect-[1980/1488]">
-                  <iframe
-                    src="https://maps.google.com/maps?q=Pattaya%20Thailand&z=12&output=embed"
-                    title="Pattaya Map"
-                    className="absolute inset-0 w-full h-full"
-                    loading="lazy"
-                    allowFullScreen
-                    referrerPolicy="no-referrer-when-downgrade"
-                  />
-                  <div className="absolute top-4 right-4 bg-white/80 backdrop-blur-md rounded-xl px-4 py-2 text-[#264f28] shadow-lg">
-                    <span className="text-sm font-medium">12.8°N, 100.9°E</span>
-                  </div>
-                </div>
-
-                {mapAdjacentHighlight && (
-                  <div className="flex justify-center mt-6 sm:mt-8">
-                    {renderHighlightCard(mapAdjacentHighlight)}
-                  </div>
-                )}
-
-                <div className="relative mt-10 sm:mt-12 lg:mt-16">
+                <div className="relative mt-6 sm:mt-8 lg:mt-10 mb-8 sm:mb-10">
                   <div
                     className="absolute inset-0 w-full h-full rounded-3xl opacity-20 -z-10"
                     style={{
@@ -152,6 +132,26 @@ export default function MapPage() {
                       className="w-full h-auto object-contain transform scale-[1.009]"
                       style={{ transformOrigin: 'center left' }}
                     />
+                  </div>
+                </div>
+
+                {mapAdjacentHighlight && (
+                  <div className="flex justify-center mt-6 sm:mt-8">
+                    {renderHighlightCard(mapAdjacentHighlight)}
+                  </div>
+                )}
+
+                <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/30 backdrop-blur-sm mt-10 sm:mt-12 lg:mt-16 mb-8 sm:mb-10 aspect-[1980/1488]">
+                  <iframe
+                    src="https://maps.google.com/maps?q=Pattaya%20Thailand&z=12&output=embed"
+                    title="Pattaya Map"
+                    className="absolute inset-0 w-full h-full"
+                    loading="lazy"
+                    allowFullScreen
+                    referrerPolicy="no-referrer-when-downgrade"
+                  />
+                  <div className="absolute top-4 right-4 bg-white/80 backdrop-blur-md rounded-xl px-4 py-2 text-[#264f28] shadow-lg">
+                    <span className="text-sm font-medium">12.8°N, 100.9°E</span>
                   </div>
                 </div>
 

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -147,7 +147,7 @@ export default function MapPage() {
                   />
                   <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/10 backdrop-blur-sm">
                     <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F2ab8e8c603ef4f25996b3b87dfc135eb?format=webp&width=800"
+                      src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F2ab8e8c603ef4f25996b3b87dfc135eb?format=webp"
                       alt="Marnfah Pool Villas location map overview"
                       className="w-full h-auto object-contain transform scale-[1.009]"
                       style={{ transformOrigin: 'center left' }}

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -161,18 +161,8 @@ export default function MapPage() {
                   </div>
                 )}
 
-                <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/30 backdrop-blur-sm mt-10 sm:mt-12 lg:mt-16 mb-8 sm:mb-10 aspect-[1980/1488]">
-                  <iframe
-                    src="https://maps.google.com/maps?q=Pattaya%20Thailand&z=12&output=embed"
-                    title="Pattaya Map"
-                    className="absolute inset-0 w-full h-full"
-                    loading="lazy"
-                    allowFullScreen
-                    referrerPolicy="no-referrer-when-downgrade"
-                  />
-                  <div className="absolute top-4 right-4 bg-white/80 backdrop-blur-md rounded-xl px-4 py-2 text-[#264f28] shadow-lg">
-                    <span className="text-sm font-medium">12.8°N, 100.9°E</span>
-                  </div>
+                <div className="relative mt-10 sm:mt-12 lg:mt-16 mb-8 sm:mb-10">
+                  {googleMapCard}
                 </div>
 
                 {secondaryHighlights.length > 0 && (

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -152,14 +152,7 @@ export default function MapPage() {
                       transform: 'scale(1.05)'
                     }}
                   />
-                  <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/10 backdrop-blur-sm">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F2ab8e8c603ef4f25996b3b87dfc135eb?format=webp"
-                      alt="Marnfah Pool Villas location map overview"
-                      className="w-full h-auto object-contain transform scale-[1.009]"
-                      style={{ transformOrigin: 'center left' }}
-                    />
-                  </div>
+                  {staticMapCard}
                 </div>
 
                 {mapAdjacentHighlight && (

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <div className="w-full flex justify-center mt-3 md:mt-9 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
+              <div className="w-full flex justify-center mt-[0.5625rem] md:mt-[1.6875rem] lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
                 <button className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium">
                   {t.exclusive.buttonText}
                 </button>

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -39,12 +39,9 @@ export default function Home() {
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
               <div className="w-full flex justify-center mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
-                <Link
-                  href="/brochure"
-                  className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium inline-flex items-center justify-center"
-                >
+                <BrochureButton>
                   {t.exclusive.buttonText}
-                </Link>
+                </BrochureButton>
               </div>
               <section id="properties">
                 <PropertiesSection />

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <div className="w-full flex justify-center mt-4 md:mt-12 lg:mt-16 xl:mt-20 mb-6 md:mb-10 lg:mb-12">
+              <div className="w-full flex justify-center mt-3 md:mt-9 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
                 <button className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium">
                   {t.exclusive.buttonText}
                 </button>

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import HeroSection from '@/components/HeroSection'
 import PropertiesSection from '@/components/PropertiesSection'

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <div className="w-full flex justify-center mt-[0.5625rem] md:mt-[1.6875rem] lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
+              <div className="w-full flex justify-center mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
                 <button className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium">
                   {t.exclusive.buttonText}
                 </button>

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import HeroSection from '@/components/HeroSection'
 import BrochureButton from '@/components/BrochureButton'
@@ -38,10 +39,16 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <div className="w-full flex justify-center mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
+              <div className="w-full flex flex-wrap items-center justify-center gap-4 mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
                 <BrochureButton>
                   {t.exclusive.buttonText}
                 </BrochureButton>
+                <Link
+                  href="/view"
+                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
+                >
+                  See All Villa Types ↗
+                </Link>
               </div>
               <section id="properties">
                 <PropertiesSection />

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import HeroSection from '@/components/HeroSection'
+import BrochureButton from '@/components/BrochureButton'
 import PropertiesSection from '@/components/PropertiesSection'
 import AmenitiesSection from '@/components/AmenitiesSection'
 import ExclusiveSection from '@/components/ExclusiveSection'

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import HeroSection from '@/components/HeroSection'
 import BrochureButton from '@/components/BrochureButton'
@@ -39,17 +38,6 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <div className="w-full flex flex-wrap items-center justify-center gap-4 mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
-                <BrochureButton>
-                  {t.exclusive.buttonText}
-                </BrochureButton>
-                <Link
-                  href="/view"
-                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
-                >
-                  See All Villa Types ↗
-                </Link>
-              </div>
               <section id="properties">
                 <PropertiesSection />
               </section>

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -39,9 +39,12 @@ export default function Home() {
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
               <div className="w-full flex justify-center mt-1 md:mt-6 lg:mt-12 xl:mt-15 mb-6 md:mb-10 lg:mb-12">
-                <button className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium">
+                <Link
+                  href="/brochure"
+                  className="px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium inline-flex items-center justify-center"
+                >
                   {t.exclusive.buttonText}
-                </button>
+                </Link>
               </div>
               <section id="properties">
                 <PropertiesSection />

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-12 md:px-14 py-3 md:py-3.5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-12 md:px-14 py-3 md:py-3.5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+import clsx from 'clsx'
+
+interface BrochureButtonProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export default function BrochureButton({ children, className }: BrochureButtonProps) {
+  const router = useRouter()
+
+  const handleClick = useCallback(() => {
+    router.push('/brochure')
+  }, [router])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={clsx(
+        'inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        className
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#264f28]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:border-[#b48828]/40 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#264f28]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -25,7 +25,10 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
         className
       )}
     >
-      {children}
+      <span className="inline-flex items-center gap-2">
+        {children}
+        <span aria-hidden="true">↗</span>
+      </span>
     </button>
   )
 }

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -26,7 +26,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       )}
     >
       <span className="inline-flex items-center gap-2">
-        {children}
+        View {children}
         <span aria-hidden="true">↗</span>
       </span>
     </button>

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -21,7 +21,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       type="button"
       onClick={handleClick}
       className={clsx(
-        'inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+        'inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-normal focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b48828]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
         className
       )}
     >

--- a/truffle-clone/src/components/ContactFooter.tsx
+++ b/truffle-clone/src/components/ContactFooter.tsx
@@ -26,7 +26,7 @@ export default function ContactFooter() {
                 onClick={() => hapticFeedback.light()}
                 className="bg-[#264f28]/10 hover:bg-[#264f28]/20 border border-[#264f28]/20 hover:border-[#264f28]/40 rounded-l-xl px-3 py-2 transition-all duration-300 hover:scale-105 transform flex items-center justify-center group"
               >
-                <span className="text-[#264f28] text-xs font-medium">{t.footer.whatsapp}</span>
+                <span className="text-[#264f28] text-xs font-medium">WhatsApp</span>
               </a>
               <a
                 href="weixin://dl/chat?MarnfahVillas"
@@ -35,7 +35,7 @@ export default function ContactFooter() {
                 onClick={() => hapticFeedback.light()}
                 className="bg-[#264f28]/10 hover:bg-[#264f28]/20 border-y border-[#264f28]/20 hover:border-[#264f28]/40 px-3 py-2 transition-all duration-300 hover:scale-105 transform flex items-center justify-center group"
               >
-                <span className="text-[#264f28] text-xs font-medium">{t.footer.wechat}</span>
+                <span className="text-[#264f28] text-xs font-medium">WeChat</span>
               </a>
               <a
                 href="https://line.me/ti/p/MarnfahPoolVillas"
@@ -44,7 +44,7 @@ export default function ContactFooter() {
                 onClick={() => hapticFeedback.light()}
                 className="bg-[#264f28]/10 hover:bg-[#264f28]/20 border border-[#264f28]/20 hover:border-[#264f28]/40 rounded-r-xl px-3 py-2 transition-all duration-300 hover:scale-105 transform flex items-center justify-center group"
               >
-                <span className="text-[#264f28] text-xs font-medium">{t.footer.line}</span>
+                <span className="text-[#264f28] text-xs font-medium">Line</span>
               </a>
             </div>
 
@@ -61,7 +61,7 @@ export default function ContactFooter() {
               sizes="(max-width: 768px) 300px, 400px"
               className="h-16 w-auto object-contain mb-3"
             />
-            <p className="text-[#264f28]/70 text-sm">{t.footer.copyright}</p>
+            <p className="text-[#264f28]/70 text-sm">© 2025 MCLL ASIA CO.</p>
             {/* Tiny spacing below copyright */}
             <div className="h-2"></div>
           </div>

--- a/truffle-clone/src/components/InvestmentSection.tsx
+++ b/truffle-clone/src/components/InvestmentSection.tsx
@@ -77,7 +77,7 @@ export default function InvestmentSection() {
                 <span>₿25M</span>
                 <span>₿20M</span>
                 <span>₿15M</span>
-                <span>₿10M</span>
+                <span>���10M</span>
                 <span>₿5M</span>
               </div>
 
@@ -185,7 +185,7 @@ export default function InvestmentSection() {
             </svg>
             {t.investment.benefits.title}
           </h3>
-          <div className="space-y-6">
+          <div className="space-y-6 lg:pt-12 lg:space-y-10">
             <div className="hidden lg:block pb-5 border-b border-[#264f28]/10 text-center">
               <div className="text-3xl font-bold text-[#264f28] mb-2">Up to 12%</div>
               <div className="text-[#b48828] font-medium mb-1">{t.investment.metrics.yield.title}</div>

--- a/truffle-clone/src/components/InvestmentSection.tsx
+++ b/truffle-clone/src/components/InvestmentSection.tsx
@@ -30,7 +30,7 @@ export default function InvestmentSection() {
 
       {/* Key Investment Metrics */}
       <div className="grid grid-cols-1 gap-6 mb-8">
-        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 border border-[#b48828]/20 text-center">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 border border-[#b48828]/20 text-center lg:hidden">
           <div className="text-3xl font-bold text-[#264f28] mb-2">Up to 12%</div>
           <div className="text-[#b48828] font-medium mb-1">{t.investment.metrics.yield.title}</div>
           <div className="text-sm text-black/60">{t.investment.metrics.tax.subtitle}</div>
@@ -186,6 +186,11 @@ export default function InvestmentSection() {
             {t.investment.benefits.title}
           </h3>
           <div className="space-y-6">
+            <div className="hidden lg:block pb-5 border-b border-[#264f28]/10 text-center">
+              <div className="text-3xl font-bold text-[#264f28] mb-2">Up to 12%</div>
+              <div className="text-[#b48828] font-medium mb-1">{t.investment.metrics.yield.title}</div>
+              <div className="text-sm text-black/60">{t.investment.metrics.tax.subtitle}</div>
+            </div>
             <div className="flex items-start gap-3 pb-5 border-b border-[#264f28]/10">
               <div className="w-4 h-4 rounded-full mt-2" style={{backgroundColor: 'rgba(180, 136, 40, 0.3)'}}></div>
               <div>

--- a/truffle-clone/src/components/InvestmentSection.tsx
+++ b/truffle-clone/src/components/InvestmentSection.tsx
@@ -77,7 +77,7 @@ export default function InvestmentSection() {
                 <span>₿25M</span>
                 <span>₿20M</span>
                 <span>₿15M</span>
-                <span>���10M</span>
+                <span>₿10M</span>
                 <span>₿5M</span>
               </div>
 
@@ -185,7 +185,7 @@ export default function InvestmentSection() {
             </svg>
             {t.investment.benefits.title}
           </h3>
-          <div className="space-y-6 lg:pt-12 lg:space-y-10">
+          <div className="space-y-6 lg:pt-12 lg:space-y-10 lg:-translate-y-[0.5cm]">
             <div className="hidden lg:block pb-5 border-b border-[#264f28]/10 text-center">
               <div className="text-3xl font-bold text-[#264f28] mb-2">Up to 12%</div>
               <div className="text-[#b48828] font-medium mb-1">{t.investment.metrics.yield.title}</div>

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -9,6 +9,15 @@ import { hapticFeedback } from '@/lib/haptics'
 import { useTranslation, languageInfo } from '@/lib/useTranslation'
 import type { Language } from '@/lib/translations'
 
+const stripNavArrow = (value: string | undefined, fallback: string): string => {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  const cleaned = value.replace(/↗/gu, '').trim()
+  return cleaned.length > 0 ? cleaned : fallback
+}
+
 export default function Navigation() {
   const [isTransitioning, setIsTransitioning] = useState(false)
   const [isLanguageDropdownOpen, setIsLanguageDropdownOpen] = useState(false)
@@ -149,7 +158,7 @@ export default function Navigation() {
                 onClick={() => hapticFeedback.light()}
                 className="hidden md:flex text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2 lg:px-3 py-2.5 lg:py-4 rounded-lg hover:bg-[#b48828]/5 text-lg lg:text-xl items-center gap-1"
               >
-                <span>{t.nav.map?.replace(' ↗', '') ?? 'Map'}</span>
+                <span>{stripNavArrow(t.nav.map, 'Map')}</span>
                 <span className="text-xl lg:text-2xl">↗</span>
               </Link>
               <Link
@@ -157,7 +166,7 @@ export default function Navigation() {
                 onClick={() => hapticFeedback.light()}
                 className="hidden md:flex text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2 lg:px-3 py-2.5 lg:py-4 rounded-lg hover:bg-[#b48828]/5 text-lg lg:text-xl items-center gap-1"
               >
-                <span>{t.nav.location.replace(' ↗', '')}</span>
+                <span>{stripNavArrow(t.nav.location, 'Gallery')}</span>
                 <span className="text-xl lg:text-2xl">↗</span>
               </Link>
               <Link
@@ -165,7 +174,7 @@ export default function Navigation() {
                 onClick={() => hapticFeedback.light()}
                 className="hidden md:flex text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2 lg:px-3 py-2.5 lg:py-4 rounded-lg hover:bg-[#b48828]/5 text-lg lg:text-xl items-center gap-1"
               >
-                <span>{t.nav.wealth.replace(' ↗', '')}</span>
+                <span>{stripNavArrow(t.nav.wealth, 'Market')}</span>
                 <span className="text-xl lg:text-2xl">↗</span>
               </Link>
             </div>
@@ -179,7 +188,7 @@ export default function Navigation() {
               className="text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2.5 py-1.5 rounded-md hover:bg-[#b48828]/5 text-base flex flex-col items-center w-16 h-16"
             >
               <span className="text-lg">↗</span>
-              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{t.nav.map?.replace(' ↗', '') ?? 'Map'}</span>
+              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{stripNavArrow(t.nav.map, 'Map')}</span>
             </Link>
             <Link
               href="/view"
@@ -187,7 +196,7 @@ export default function Navigation() {
               className="text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2.5 py-1.5 rounded-md hover:bg-[#b48828]/5 text-base flex flex-col items-center w-16 h-16"
             >
               <span className="text-lg">↗</span>
-              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{t.nav.location.replace(' ↗', '')}</span>
+              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{stripNavArrow(t.nav.location, 'Gallery')}</span>
             </Link>
             <Link
               href="/capital"
@@ -195,7 +204,7 @@ export default function Navigation() {
               className="text-[#264f28] font-medium hover:text-[#b48828] transition-all duration-300 hover:scale-105 hover:drop-shadow-md transform px-2.5 py-1.5 rounded-md hover:bg-[#b48828]/5 text-base flex flex-col items-center w-16 h-16"
             >
               <span className="text-lg">↗</span>
-              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{t.nav.wealth.replace(' ↗', '')}</span>
+              <span className={`font-medium ${language === 'en' ? 'text-base' : language === 'ru' ? 'text-xs' : language === 'ja' ? 'text-sm' : 'text-base'}`}>{stripNavArrow(t.nav.wealth, 'Market')}</span>
             </Link>
           </div>
 

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,7 +133,7 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[2cm] md:mt-[2cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,14 +128,6 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
-                <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex justify-center md:justify-start">
-                  <Link
-                    href="/view"
-                    className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
-                  >
-                    See All Villa Types ↗
-                  </Link>
-                </div>
               </div>
           </div>
         </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,7 +133,7 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[2cm] md:mt-[2cm] lg:mt-0"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[1cm] md:mt-[1cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,11 +133,11 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
+                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-normal"
                 >
                   See All Villa Types ↗
                 </Link>
-                <BrochureButton className="font-semibold italic">
+                <BrochureButton className="font-normal">
                   {t.exclusive.buttonText}
                 </BrochureButton>
               </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,7 +133,7 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,14 +133,14 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-12 md:px-14 py-3 md:py-3.5 min-w-[13.5rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types
                     <span aria-hidden="true">↗</span>
                   </span>
                 </Link>
-                <BrochureButton className="font-normal min-w-[13.5rem]">
+                <BrochureButton className="font-normal min-w-[11rem]">
                   {t.exclusive.buttonText}
                 </BrochureButton>
               </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,7 +128,7 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
-                <div className="mt-10 md:mt-12 flex justify-center md:justify-start mb-6 md:mb-10">
+                <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex justify-center md:justify-start">
                   <Link
                     href="/view"
                     className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,7 +128,7 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
-                <div className="mt-10 md:mt-12 flex justify-center md:justify-start">
+                <div className="mt-10 md:mt-12 flex justify-center md:justify-start mb-6 md:mb-10">
                   <Link
                     href="/view"
                     className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -1,5 +1,6 @@
 // CACHE BUST v68 - FORCED VILLA ORDER: Tranquility (12.3M) → Serenity (18.8M) → Harmony (23.4M) THB
 
+import Link from 'next/link'
 import { useTranslation } from '@/lib/useTranslation'
 
 export default function PropertiesSection() {

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,14 +133,14 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 min-w-[15rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
+                  className="inline-flex items-center justify-center px-12 md:px-14 py-3 md:py-3.5 min-w-[13.5rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types
                     <span aria-hidden="true">↗</span>
                   </span>
                 </Link>
-                <BrochureButton className="font-normal min-w-[15rem]">
+                <BrochureButton className="font-normal min-w-[13.5rem]">
                   {t.exclusive.buttonText}
                 </BrochureButton>
               </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,14 +133,14 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
+                  className="inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 min-w-[15rem] rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types
                     <span aria-hidden="true">↗</span>
                   </span>
                 </Link>
-                <BrochureButton className="font-normal">
+                <BrochureButton className="font-normal min-w-[15rem]">
                   {t.exclusive.buttonText}
                 </BrochureButton>
               </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
+              <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,7 +128,7 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
-                <div className="flex justify-center md:justify-start" style={{ marginTop: '0.5cm' }}>
+                <div className="mt-10 md:mt-12 flex justify-center md:justify-start">
                   <Link
                     href="/view"
                     className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,9 +133,12 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-normal"
+                  className="inline-flex items-center justify-center px-14 md:px-16 py-3.5 md:py-4 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-base md:text-lg font-normal"
                 >
-                  See All Villa Types ↗
+                  <span className="inline-flex items-center gap-2">
+                    See All Villa Types
+                    <span aria-hidden="true">↗</span>
+                  </span>
                 </Link>
                 <BrochureButton className="font-normal">
                   {t.exclusive.buttonText}

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -1,5 +1,7 @@
 // CACHE BUST v68 - FORCED VILLA ORDER: Tranquility (12.3M) → Serenity (18.8M) → Harmony (23.4M) THB
 
+import Link from 'next/link'
+import BrochureButton from '@/components/BrochureButton'
 import { useTranslation } from '@/lib/useTranslation'
 
 export default function PropertiesSection() {
@@ -127,6 +129,17 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
+              </div>
+              <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-wrap items-center justify-center gap-4 md:justify-start">
+                <Link
+                  href="/view"
+                  className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
+                >
+                  See All Villa Types ↗
+                </Link>
+                <BrochureButton className="font-semibold italic">
+                  {t.exclusive.buttonText}
+                </BrochureButton>
               </div>
           </div>
         </div>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,8 +130,8 @@ export default function PropertiesSection() {
                 </div>
                 <div className="mt-4 flex justify-center md:justify-start">
                   <Link
-                    href="/brochure"
-                    className="inline-flex items-center gap-2 px-5 py-2 rounded-full border border-[#b48828]/40 bg-white/90 text-[#264f28] font-semibold italic tracking-wide shadow-sm hover:bg-[#b48828]/10 hover:text-[#b48828] transition-colors duration-300"
+                    href="/view"
+                    className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"
                   >
                     See All Villa Types ↗
                   </Link>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,7 +128,7 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
-                <div className="mt-4 flex justify-center md:justify-start">
+                <div className="flex justify-center md:justify-start" style={{ marginTop: '0.5cm' }}>
                   <Link
                     href="/view"
                     className="inline-flex items-center justify-center px-16 md:px-20 py-4 md:py-5 rounded-2xl bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#b48828]/20 hover:scale-105 text-lg md:text-xl font-semibold italic"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -1,6 +1,5 @@
 // CACHE BUST v68 - FORCED VILLA ORDER: Tranquility (12.3M) → Serenity (18.8M) → Harmony (23.4M) THB
 
-import Link from 'next/link'
 import { useTranslation } from '@/lib/useTranslation'
 
 export default function PropertiesSection() {

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -128,6 +128,14 @@ export default function PropertiesSection() {
                     </div>
                   </div>
                 </div>
+                <div className="mt-4 flex justify-center md:justify-start">
+                  <Link
+                    href="/brochure"
+                    className="inline-flex items-center gap-2 px-5 py-2 rounded-full border border-[#b48828]/40 bg-white/90 text-[#264f28] font-semibold italic tracking-wide shadow-sm hover:bg-[#b48828]/10 hover:text-[#b48828] transition-colors duration-300"
+                  >
+                    See All Villa Types ↗
+                  </Link>
+                </div>
               </div>
           </div>
         </div>

--- a/truffle-clone/src/lib/translations.ts
+++ b/truffle-clone/src/lib/translations.ts
@@ -193,7 +193,7 @@ const englishTranslationsData = {
     }
   },
   virtualTour: {
-    title: "Virtual Villa Experience",
+    title: "Luxury Villa Experience",
     subtitle: "Explore our luxury villas with immersive 360° tours",
     features: {
       views360: {

--- a/truffle-clone/src/lib/translations.ts
+++ b/truffle-clone/src/lib/translations.ts
@@ -175,7 +175,7 @@ const englishTranslationsData = {
     },
     stability: {
       title: "Thailand Economic Stability & Growth",
-      description: "Thailand's stable political environment and robust tourism industry within Southeast Asia has created an exponential market for investors. The government's pro-investment policies and immense infrastructure development continue to drive smart money opportunities.",
+      description: "Thailand's stable political environment and robust tourism industry within Southeast Asia has created an exponential market for investors. The government's pro-investment policies and rapid infrastructure development shows the next decades are fruitful.",
       metrics: {
         rating: {
           title: "Credit Rating",


### PR DESCRIPTION
## Purpose

The user requested multiple UI improvements focused on standardizing button sizes and styling across the villa types and brochure buttons. They wanted both buttons to match in size, be made progressively smaller, change colors (green then back to gold for brochure), update button labels, and adjust spacing on mobile/tablet views. The goal was to create a consistent, polished button interface with proper responsive behavior.

## Code changes

- **New brochure page**: Added `/brochure` route with image gallery functionality and API endpoint for dynamic image loading
- **Button styling updates**: Modified villa types and brochure buttons in PropertiesSection to match sizes and updated responsive spacing
- **Navigation improvements**: Added utility function to strip arrow symbols from navigation labels for cleaner display
- **Investment section layout**: Reorganized metrics display with better responsive positioning and spacing
- **Content updates**: Updated translation strings for ownership descriptions and virtual tour titles
- **Map page enhancements**: Added static map card component alongside existing Google Maps integrationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e5fdd11587534640ab84596faaf47bce/neon-works)

👀 [Preview Link](https://e5fdd11587534640ab84596faaf47bce-neon-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5fdd11587534640ab84596faaf47bce</projectId>-->
<!--<branchName>neon-works</branchName>-->