### PR TITLE
Add villa descriptions and view buttons to gallery cards

### DIFF
--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function Home() {
               <section id="properties" className="-mt-[0.5cm]">
                 <PropertiesSection />
               </section>
-              <section id="amenities">
+              <section id="amenities" className="-mt-[0.5cm]">
                 <AmenitiesSection />
               </section>
               <ExclusiveSection />

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
                 <AmenitiesSection />
               </section>
               <ExclusiveSection />
-              <section id="contact" className="pt-6 sm:pt-6 md:pt-8 lg:pt-12 px-4 sm:px-6" style={{ margin: 0, paddingBottom: 0, minHeight: 'auto' }}>
+              <section id="contact" className="pt-0 sm:pt-0 md:pt-0 lg:pt-12 px-4 sm:px-6" style={{ margin: 0, paddingBottom: 0, minHeight: 'auto' }}>
                 <ContactForm />
               </section>
               {/* Spacing between contact form and footer */}

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <section id="properties">
+              <section id="properties" className="-mt-[0.5cm]">
                 <PropertiesSection />
               </section>
               <section id="amenities">

--- a/truffle-clone/src/app/page.tsx
+++ b/truffle-clone/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
             <div className="relative w-full" style={{ margin: 0, padding: 0 }}>
               <HeroSection />
               {/* View Brochure Button - positioned between hero and properties */}
-              <section id="properties" className="-mt-[0.5cm]">
+              <section id="properties" className="-mt-[0.5cm] lg:mt-[0.5cm]">
                 <PropertiesSection />
               </section>
               <section id="amenities" className="-mt-[0.5cm]">

--- a/truffle-clone/src/components/AmenitiesSection.tsx
+++ b/truffle-clone/src/components/AmenitiesSection.tsx
@@ -5,7 +5,7 @@ export default function AmenitiesSection() {
   return (
     <div className="max-w-7xl mx-auto pt-0 pb-6 sm:pt-0 sm:pb-10 md:pt-0 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col lg:flex-row items-center justify-between gap-y-8 lg:gap-x-12">
       <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start">
-        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium lg:pl-[0.5cm]">
+        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mt-[0.25cm] sm:mt-0 lg:pl-[0.5cm]">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
           </svg>

--- a/truffle-clone/src/components/AmenitiesSection.tsx
+++ b/truffle-clone/src/components/AmenitiesSection.tsx
@@ -10,7 +10,7 @@ export default function AmenitiesSection() {
             <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
           </svg>
         </div>
-        <div className="relative mb-6 text-center md:text-left">
+        <div className="relative mb-6 text-center md:text-left lg:pl-[0.5cm]">
           <h1 className="text-3xl md:text-5xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
             <span className="relative inline-block">
               <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm"></span>
@@ -21,7 +21,7 @@ export default function AmenitiesSection() {
           </h1>
           <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full"></div>
         </div>
-        <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line">
+        <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm]">
           {t.amenities.description}
         </div>
       </div>

--- a/truffle-clone/src/components/AmenitiesSection.tsx
+++ b/truffle-clone/src/components/AmenitiesSection.tsx
@@ -3,7 +3,7 @@ import { useT } from '@/lib/useTranslation'
 export default function AmenitiesSection() {
   const t = useT()
   return (
-    <div className="max-w-7xl mx-auto pt-6 pb-6 sm:pt-8 sm:pb-10 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col lg:flex-row items-center justify-between gap-y-8 lg:gap-x-12">
+    <div className="max-w-7xl mx-auto pt-0 pb-6 sm:pt-0 sm:pb-10 md:pt-0 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col lg:flex-row items-center justify-between gap-y-8 lg:gap-x-12">
       <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start">
         <div className="inline-flex items-center gap-2 text-[#b48828] font-medium lg:pl-[0.5cm]">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">

--- a/truffle-clone/src/components/AmenitiesSection.tsx
+++ b/truffle-clone/src/components/AmenitiesSection.tsx
@@ -5,7 +5,7 @@ export default function AmenitiesSection() {
   return (
     <div className="max-w-7xl mx-auto pt-6 pb-6 sm:pt-8 sm:pb-10 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col lg:flex-row items-center justify-between gap-y-8 lg:gap-x-12">
       <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start">
-        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium">
+        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium lg:pl-[0.5cm]">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
           </svg>
@@ -19,7 +19,7 @@ export default function AmenitiesSection() {
               </span>
             </span>
           </h1>
-          <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full"></div>
+          <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full lg:left-[0.5cm]"></div>
         </div>
         <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm]">
           {t.amenities.description}

--- a/truffle-clone/src/components/ExclusiveSection.tsx
+++ b/truffle-clone/src/components/ExclusiveSection.tsx
@@ -3,7 +3,7 @@ import { useT } from '@/lib/useTranslation'
 export default function ExclusiveSection() {
   const t = useT()
   return (
-    <div className="max-w-7xl mx-auto pt-6 pb-6 sm:pt-8 sm:pb-10 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col-reverse lg:flex-row items-center justify-between gap-y-6 sm:gap-y-8 lg:gap-y-10 lg:gap-x-12">
+    <div className="max-w-7xl mx-auto pt-0 pb-6 sm:pt-0 sm:pb-10 md:pt-0 lg:pt-20 lg:pb-20 px-4 sm:px-6 flex flex-col-reverse lg:flex-row items-center justify-between gap-y-6 sm:gap-y-8 lg:gap-y-10 lg:gap-x-12">
       <div className="w-full lg:w-1/2 flex justify-center relative">
         {/* Glow effect behind the image */}
         <div

--- a/truffle-clone/src/components/ExclusiveSection.tsx
+++ b/truffle-clone/src/components/ExclusiveSection.tsx
@@ -22,8 +22,8 @@ export default function ExclusiveSection() {
 
         </div>
       </div>
-      <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start">
-        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium">
+      <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start mt-3 sm:mt-0">
+        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mt-[9px]">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
           </svg>

--- a/truffle-clone/src/components/ExclusiveSection.tsx
+++ b/truffle-clone/src/components/ExclusiveSection.tsx
@@ -22,8 +22,8 @@ export default function ExclusiveSection() {
 
         </div>
       </div>
-      <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start mt-3 sm:mt-0">
-        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mt-[9px]">
+      <div className="flex flex-col gap-y-6 w-full lg:w-1/2 h-full lg:h-[500px] xl:h-[600px] justify-center items-center md:items-start mt-0 sm:mt-0">
+        <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mt-0 sm:mt-[9px]">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
           </svg>

--- a/truffle-clone/src/components/HeroSection.tsx
+++ b/truffle-clone/src/components/HeroSection.tsx
@@ -72,7 +72,7 @@ export default function HeroSection() {
             </div>
             <div className="relative w-full px-4 md:px-8 lg:px-12">
               <div>
-                <p className="text-[15px] text-white text-center font-medium lg:text-[22px] xl:text-[24px]" style={{
+                <p className="text-[15px] text-white text-center font-medium md:text-[19px] lg:text-[22px] xl:text-[24px]" style={{
                   WebkitTextStroke: '0.1px #d4af37',
                   textShadow: '0 0 0.5px #d4af37',
                   lineHeight: '1.6'

--- a/truffle-clone/src/components/HeroSection.tsx
+++ b/truffle-clone/src/components/HeroSection.tsx
@@ -72,7 +72,7 @@ export default function HeroSection() {
             </div>
             <div className="relative w-full px-4 md:px-8 lg:px-12">
               <div>
-                <p className="text-[15px] text-white text-center font-medium md:text-[19px] lg:text-[22px] xl:text-[24px]" style={{
+                <p className="text-[15px] text-white text-center font-medium md:text-[22px] lg:text-[22px] xl:text-[24px]" style={{
                   WebkitTextStroke: '0.1px #d4af37',
                   textShadow: '0 0 0.5px #d4af37',
                   lineHeight: '1.6'

--- a/truffle-clone/src/components/HeroSection.tsx
+++ b/truffle-clone/src/components/HeroSection.tsx
@@ -72,7 +72,7 @@ export default function HeroSection() {
             </div>
             <div className="relative w-full px-4 md:px-8 lg:px-12">
               <div>
-                <p className="text-[15px] text-white text-center font-medium" style={{
+                <p className="text-[15px] text-white text-center font-medium lg:text-[22px] xl:text-[24px]" style={{
                   WebkitTextStroke: '0.1px #d4af37',
                   textShadow: '0 0 0.5px #d4af37',
                   lineHeight: '1.6'

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -362,6 +362,7 @@ export default function Navigation() {
                   src={option.imgSrc}
                   alt={option.label}
                   className="w-full h-full object-cover"
+                  style={option.key === 'whatsapp' ? { transform: 'scale(1.1) translate(4px, -4px)', transformOrigin: 'center' } : undefined}
                   loading="lazy"
                 />
               </a>

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -362,7 +362,7 @@ export default function Navigation() {
                   src={option.imgSrc}
                   alt={option.label}
                   className="w-full h-full object-cover"
-                  style={option.key === 'whatsapp' ? { transform: 'scale(1.1) translate(4px, -4px)', transformOrigin: 'center' } : undefined}
+                  style={option.key === 'whatsapp' ? { transform: 'scale(1.1)', transformOrigin: 'center' } : undefined}
                   loading="lazy"
                 />
               </a>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-[0.25cm] md:mb-0 md:mt-12 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[1cm]">
+              <div className="mt-10 mb-[0.25cm] md:mb-0 md:mt-12 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[1cm] pb-[0.5cm] sm:pb-0">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -17,7 +17,7 @@ export default function PropertiesSection() {
                 <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
               </svg>
             </div>
-            <div className="relative mb-6 text-center md:text-left">
+            <div className="relative mb-6 text-center md:text-left lg:pl-[0.5cm]">
               <h1 className="text-3xl md:text-5xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
                 <span className="relative inline-block">
                   <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm"></span>
@@ -29,7 +29,7 @@ export default function PropertiesSection() {
               <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full"></div>
             </div>
           </div>
-          <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line">
+          <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm]">
             {t.properties.description}
           </div>
 

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[0.5cm]">
+              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[1cm]">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -133,7 +133,7 @@ export default function PropertiesSection() {
               <div className="mt-10 mb-0 md:mt-12 md:mb-[0.25cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.5cm] md:mt-[0.5cm] lg:mt-0"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -12,7 +12,7 @@ export default function PropertiesSection() {
       <div className="bg-[#ede5d9]/50 w-full villa-section-no-scroll">
         <div className="flex flex-col gap-y-4 max-w-7xl mx-auto pt-0 pb-6 sm:pb-10 px-4 sm:px-6 villa-section-no-scroll">
           <div className="relative flex flex-col items-center md:items-start">
-            <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mb-4">
+            <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mb-4 lg:pl-[0.5cm]">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
               </svg>
@@ -26,7 +26,7 @@ export default function PropertiesSection() {
                   </span>
                 </span>
               </h1>
-              <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full"></div>
+              <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full lg:left-[0.5cm]"></div>
             </div>
           </div>
           <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm]">

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,10 +130,10 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-10 md:mt-12 md:mb-12 flex flex-col items-center gap-4 md:flex-col md:items-start">
+              <div className="mt-10 mb-[0.75cm] md:mt-12 md:mb-[1cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
-                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[1cm] md:mt-[1cm] lg:mt-0"
+                  className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.5cm] md:mt-[0.5cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
                     See All Villa Types

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -12,7 +12,7 @@ export default function PropertiesSection() {
       <div className="bg-[#ede5d9]/50 w-full villa-section-no-scroll">
         <div className="flex flex-col gap-y-4 max-w-7xl mx-auto pt-0 pb-6 sm:pb-10 px-4 sm:px-6 villa-section-no-scroll">
           <div className="relative flex flex-col items-center md:items-start">
-            <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mb-4 lg:pl-[0.5cm]">
+            <div className="inline-flex items-center gap-2 text-[#b48828] font-medium mb-4 lg:pl-[0.5cm] lg:mt-[0.5cm]">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2L14.5 8.5L21 8.5L16 13L17.5 19.5L12 16L6.5 19.5L8 13L3 8.5L9.5 8.5L12 2Z"/>
               </svg>
@@ -29,7 +29,7 @@ export default function PropertiesSection() {
               <div className="absolute -top-2 left-0 md:left-0 right-0 md:right-auto mx-auto md:mx-0 w-16 h-1 bg-gradient-to-r from-[#b48828] to-[#d4af37] rounded-full lg:left-[0.5cm]"></div>
             </div>
           </div>
-          <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm]">
+          <div className="text-lg sm:text-xl text-[#264f28] leading-relaxed text-center md:text-left whitespace-pre-line lg:pl-[0.5cm] lg:mb-[0.5cm]">
             {t.properties.description}
           </div>
 
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2">
+              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[0.5cm]">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-0 md:mt-12 md:mb-[0.25cm] flex flex-col items-center gap-4 md:items-center lg:col-start-2">
+              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-[0.5cm] md:mt-12 md:mb-[0.75cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
+              <div className="mt-10 mb-0 md:mt-12 md:mb-[0.25cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.5cm] md:mt-[0.5cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-[0.75cm] md:mt-12 md:mb-[1cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
+              <div className="mt-10 mb-[0.5cm] md:mt-12 md:mb-[0.75cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.5cm] md:mt-[0.5cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -34,7 +34,7 @@ export default function PropertiesSection() {
           </div>
 
           {/* Villa Grid - Three columns on desktop, single column on mobile */}
-          <div className="w-full space-y-6 lg:grid lg:grid-cols-3 lg:gap-8 xl:gap-10 lg:space-y-0 mt-6 villa-section-no-scroll villa-container-static">
+          <div className="w-full space-y-6 lg:grid lg:grid-cols-3 lg:gap-8 xl:gap-10 lg:space-y-0 mt-6 lg:mt-0 villa-section-no-scroll villa-container-static">
               {/* FIRST VILLA: Harmony - MOST EXPENSIVE at ฿23.4M THB */}
               <div className="w-full group relative villa-container-static">
                 {/* Glow effect behind the image */}

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-0 md:mt-12 md:mb-0 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[1cm]">
+              <div className="mt-10 mb-[0.25cm] md:mb-0 md:mt-12 flex flex-col items-center gap-4 md:items-center lg:col-start-2 lg:mt-[1cm]">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -35,7 +35,7 @@ export default function PropertiesSection() {
 
           {/* Villa Grid - Three columns on desktop, single column on mobile */}
           <div className="w-full space-y-6 lg:grid lg:grid-cols-3 lg:gap-8 xl:gap-10 lg:space-y-0 mt-6 villa-section-no-scroll villa-container-static">
-              {/* FIRST VILLA: Tranquility - CHEAPEST at ฿12.3M THB */}
+              {/* FIRST VILLA: Harmony - MOST EXPENSIVE at ฿23.4M THB */}
               <div className="w-full group relative villa-container-static">
                 {/* Glow effect behind the image */}
                 <div
@@ -48,17 +48,17 @@ export default function PropertiesSection() {
                 />
                 <div className="relative aspect-[4/3] lg:aspect-[3/4] xl:aspect-square rounded-3xl md:shadow-2xl w-full overflow-hidden border-8 border-[#b48828]/30">
                   <img
-                    src="/villa4.jpg"
-                    alt="Tranquility - Contemporary Pool Villa"
+                    src="/villa2.jpg"
+                    alt="Harmony - Luxury Pool Terrace Villa"
                     className="w-full h-full object-cover"
                   />
 
                   <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                   <div className="absolute bottom-0 left-0 right-0 p-4 lg:p-6 text-white">
                     <div className="text-center md:text-left">
-                      <h3 className="text-lg lg:text-xl font-semibold mb-0.5">{t.properties.villa1.name}</h3>
+                      <h3 className="text-lg lg:text-xl font-semibold mb-0.5">{t.properties.villa3.name}</h3>
                       <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        {t.properties.villa1.features}
+                        {t.properties.villa3.features}
                         <span className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
                               style={{boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)'}}></span>
                       </p>
@@ -99,7 +99,7 @@ export default function PropertiesSection() {
                 </div>
               </div>
 
-              {/* THIRD VILLA: Harmony - MOST EXPENSIVE at ฿23.4M THB */}
+              {/* THIRD VILLA: Tranquility - CHEAPEST at ฿12.3M THB */}
               <div className="w-full group relative villa-container-static">
                 {/* Glow effect behind the image */}
                 <div
@@ -112,17 +112,17 @@ export default function PropertiesSection() {
                 />
                 <div className="relative aspect-[4/3] lg:aspect-[3/4] xl:aspect-square rounded-3xl md:shadow-2xl w-full overflow-hidden border-8 border-[#b48828]/30">
                   <img
-                    src="/villa2.jpg"
-                    alt="Harmony - Luxury Pool Terrace Villa"
+                    src="/villa4.jpg"
+                    alt="Tranquility - Contemporary Pool Villa"
                     className="w-full h-full object-cover"
                   />
 
                   <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                   <div className="absolute bottom-0 left-0 right-0 p-4 lg:p-6 text-white">
                     <div className="text-center md:text-left">
-                      <h3 className="text-lg lg:text-xl font-semibold mb-0.5">{t.properties.villa3.name}</h3>
+                      <h3 className="text-lg lg:text-xl font-semibold mb-0.5">{t.properties.villa1.name}</h3>
                       <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        {t.properties.villa3.features}
+                        {t.properties.villa1.features}
                         <span className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
                               style={{boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)'}}></span>
                       </p>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -130,7 +130,7 @@ export default function PropertiesSection() {
                   </div>
                 </div>
               </div>
-              <div className="mt-10 mb-0 md:mt-12 md:mb-[0.25cm] flex flex-col items-center gap-4 md:flex-col md:items-start">
+              <div className="mt-10 mb-0 md:mt-12 md:mb-[0.25cm] flex flex-col items-center gap-4 md:items-center lg:col-start-2">
                 <Link
                   href="/view"
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -96,7 +96,7 @@ export default function VirtualTourSection() {
       </div>
 
       {/* Villa Tour Selection */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 overflow-hidden sm:overflow-visible">
+      <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden sm:overflow-visible">
         {villas.map((villa) => (
           <div key={villa.id} className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden transition-all duration-300 sm:group-hover:scale-[1.02]">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -69,6 +69,12 @@ export default function VirtualTourSection() {
     setCurrentRoom(0)
   }
 
+  const villaDetails: Record<string, string> = {
+    type1: '5 Bed - 6 Bath - 592 sqm.',
+    type2: '4 Bed - 5 Bath - 457 sqm.',
+    type3: '4 Bed - 5 Bath - 382.5 sqm.'
+  }
+
   const selectedVillaData = villas.find(v => v.id === selectedVilla)
 
   return (

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -114,22 +114,22 @@ export default function VirtualTourSection() {
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                 <div className="absolute bottom-4 left-4 right-4 text-white">
-                  <div className="flex flex-col gap-2 text-left">
-                    <div>
-                      <h3 className="text-xl font-semibold mb-1">{villa.name}</h3>
+                  <div className="flex items-end justify-between gap-3 text-left">
+                    <div className="flex flex-col gap-1">
+                      <h3 className="text-xl font-semibold">{villa.name}</h3>
                       {villaDetails[villa.id] && (
-                        <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                        <p className="text-white/90 text-sm lg:text-base pb-1 relative">
                           {villaDetails[villa.id]}
                           <span
-                            className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                            style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                            className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                            style={{ boxShadow: '0 0 4px rgba(255, 255, 255, 0.3), 0 0 8px rgba(212, 175, 55, 0.2)' }}
                           ></span>
                         </p>
                       )}
                     </div>
                     <button
                       type="button"
-                      className="self-end text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                      className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
                     >
                       View Pictures ↗
                     </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -112,7 +112,25 @@ export default function VirtualTourSection() {
                     <h3 className="text-xl font-semibold mb-1">{villa.name}</h3>
                     {villa.id === 'type1' && (
                       <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        - 5 Bed - 6 Bath - 592 sqm.
+                        5 Bed - 6 Bath - 592 sqm.
+                        <span
+                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                        ></span>
+                      </p>
+                    )}
+                    {villa.id === 'type2' && (
+                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                        4 Bed - 5 Bath - 457 sqm.
+                        <span
+                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                        ></span>
+                      </p>
+                    )}
+                    {villa.id === 'type3' && (
+                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                        4 Bed - 5 Bath - 382.5 sqm.
                         <span
                           className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
                           style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
@@ -136,7 +154,16 @@ export default function VirtualTourSection() {
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
               <div className="absolute bottom-4 left-4 right-4 text-white">
-                <h3 className="text-xl font-semibold">Villa Type 4</h3>
+                <div className="text-left">
+                  <h3 className="text-xl font-semibold mb-1">Villa Type 4</h3>
+                  <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                    4 Bed - 5 Bath - 353 sqm.
+                    <span
+                      className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                      style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                    ></span>
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -108,7 +108,18 @@ export default function VirtualTourSection() {
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                 <div className="absolute bottom-4 left-4 right-4 text-white">
-                  <h3 className="text-xl font-semibold">{villa.name}</h3>
+                  <div className="text-left">
+                    <h3 className="text-xl font-semibold mb-1">{villa.name}</h3>
+                    {villa.id === 'type1' && (
+                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                        - 5 Bed - 6 Bath - 592 sqm.
+                        <span
+                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                        ></span>
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -150,20 +150,20 @@ export default function VirtualTourSection() {
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
               <div className="absolute bottom-4 left-4 right-4 text-white">
-                <div className="flex flex-col gap-2 text-left">
-                  <div>
-                    <h3 className="text-xl font-semibold mb-1">Villa Type 4</h3>
-                    <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                <div className="flex items-end justify-between gap-3 text-left">
+                  <div className="flex flex-col gap-1">
+                    <h3 className="text-xl font-semibold">Villa Type 4</h3>
+                    <p className="text-white/90 text-sm lg:text-base pb-1 relative">
                       4 Bed - 5 Bath - 353 sqm.
                       <span
-                        className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                        style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                        className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                        style={{ boxShadow: '0 0 4px rgba(255, 255, 255, 0.3), 0 0 8px rgba(212, 175, 55, 0.2)' }}
                       ></span>
                     </p>
                   </div>
                   <button
                     type="button"
-                    className="self-end text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                    className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
                   >
                     View Pictures ↗
                   </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -97,8 +97,8 @@ export default function VirtualTourSection() {
 
       {/* Villa Tour Selection */}
       <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden sm:overflow-visible">
-        {villas.map((villa) => (
-          <div key={villa.id} className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
+        {villas.map((villa, index) => (
+          <div key={`${villa.id}-${index}`} className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden transition-all duration-300 sm:group-hover:scale-[1.02]">
               <div className="relative h-64 overflow-hidden">
                 <img
@@ -115,6 +115,22 @@ export default function VirtualTourSection() {
             </div>
           </div>
         ))}
+        <div className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
+          <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden transition-all duration-300 sm:group-hover:scale-[1.02]">
+            <div className="relative h-64 overflow-hidden">
+              <img
+                src={villas[0].image}
+                alt={villas[0].name}
+                className="w-full h-full object-cover transition-transform duration-300 sm:group-hover:scale-110"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
+              <div className="absolute bottom-4 left-4 right-4 text-white">
+                <h3 className="text-xl font-semibold">{villas[0].name}</h3>
+              </div>
+            </div>
+
+          </div>
+        </div>
       </div>
 
       {/* Virtual Tour Modal */}

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -114,35 +114,25 @@ export default function VirtualTourSection() {
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                 <div className="absolute bottom-4 left-4 right-4 text-white">
-                  <div className="text-left">
-                    <h3 className="text-xl font-semibold mb-1">{villa.name}</h3>
-                    {villa.id === 'type1' && (
-                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        5 Bed - 6 Bath - 592 sqm.
-                        <span
-                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
-                        ></span>
-                      </p>
-                    )}
-                    {villa.id === 'type2' && (
-                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        4 Bed - 5 Bath - 457 sqm.
-                        <span
-                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
-                        ></span>
-                      </p>
-                    )}
-                    {villa.id === 'type3' && (
-                      <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                        4 Bed - 5 Bath - 382.5 sqm.
-                        <span
-                          className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                          style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
-                        ></span>
-                      </p>
-                    )}
+                  <div className="flex flex-col gap-2 text-left">
+                    <div>
+                      <h3 className="text-xl font-semibold mb-1">{villa.name}</h3>
+                      {villaDetails[villa.id] && (
+                        <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                          {villaDetails[villa.id]}
+                          <span
+                            className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                            style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                          ></span>
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className="self-end text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                    >
+                      View Pictures ↗
+                    </button>
                   </div>
                 </div>
               </div>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -150,15 +150,23 @@ export default function VirtualTourSection() {
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
               <div className="absolute bottom-4 left-4 right-4 text-white">
-                <div className="text-left">
-                  <h3 className="text-xl font-semibold mb-1">Villa Type 4</h3>
-                  <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
-                    4 Bed - 5 Bath - 353 sqm.
-                    <span
-                      className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
-                      style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
-                    ></span>
-                  </p>
+                <div className="flex flex-col gap-2 text-left">
+                  <div>
+                    <h3 className="text-xl font-semibold mb-1">Villa Type 4</h3>
+                    <p className="text-white/90 text-sm lg:text-base mb-1 pb-1 relative">
+                      4 Bed - 5 Bath - 353 sqm.
+                      <span
+                        className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+                        style={{ boxShadow: '0 0 8px rgba(255, 255, 255, 0.3), 0 0 16px rgba(212, 175, 55, 0.2)' }}
+                      ></span>
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="self-end text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                  >
+                    View Pictures ↗
+                  </button>
                 </div>
               </div>
             </div>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -120,12 +120,12 @@ export default function VirtualTourSection() {
             <div className="relative h-64 overflow-hidden">
               <img
                 src={villas[0].image}
-                alt={villas[0].name}
+                alt="Villa Type 4"
                 className="w-full h-full object-cover transition-transform duration-300 sm:group-hover:scale-110"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
               <div className="absolute bottom-4 left-4 right-4 text-white">
-                <h3 className="text-xl font-semibold">{villas[0].name}</h3>
+                <h3 className="text-xl font-semibold">Villa Type 4</h3>
               </div>
             </div>
 


### PR DESCRIPTION
## Purpose

The user wanted to enhance the villa gallery page by adding detailed property information and navigation elements to improve the user experience. The goal was to make villa cards more informative by displaying specifications (bedrooms, bathrooms, square footage) and adding quick access to view more pictures, while maintaining visual consistency with the home page design.

## Code changes

- **Villa card descriptions**: Added property specifications (bed/bath/sqm) to all 4 villa types in the gallery
- **View Pictures buttons**: Added small "View Pictures ↗" buttons positioned at bottom-right of each villa card
- **Typography adjustments**: Made underlines beneath villa titles 50% thinner (0.5px height)
- **Layout positioning**: Moved villa titles and descriptions to bottom-left corner, aligned horizontally with view buttons
- **Spacing improvements**: Adjusted margins and padding across sections for better visual flow
- **Hero section text**: Increased font size for better readability on medium and large screens
- **Navigation icon**: Applied slight scaling to WhatsApp icon for better visual balanceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e5fdd11587534640ab84596faaf47bce/neon-verse)

👀 [Preview Link](https://e5fdd11587534640ab84596faaf47bce-neon-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5fdd11587534640ab84596faaf47bce</projectId>-->
<!--<branchName>neon-verse</branchName>-->