### PR TITLE
Fix navigation positioning and add CTA translation overrides

### DIFF
--- a/truffle-clone/next.config.js
+++ b/truffle-clone/next.config.js
@@ -1,7 +1,15 @@
 const nextConfig = {
   output: 'export',
   distDir: 'out',
-  allowedDevOrigins: ['builder.io', 'https://builder.io', '*.fly.dev', 'e5fdd11587534640ab84596faaf47bce-2e1a48e0-0808-4133-9129-94138a.fly.dev', 'https://e5fdd11587534640ab84596faaf47bce-2e1a48e0-0808-4133-9129-94138a.fly.dev'],
+  allowedDevOrigins: [
+    'builder.io',
+    'https://builder.io',
+    '*.fly.dev',
+    'e5fdd11587534640ab84596faaf47bce-2e1a48e0-0808-4133-9129-94138a.fly.dev',
+    'https://e5fdd11587534640ab84596faaf47bce-2e1a48e0-0808-4133-9129-94138a.fly.dev',
+    'e5fdd11587534640ab84596faaf47bce-d61babbe-826f-4152-b835-218f3c.fly.dev',
+    'https://e5fdd11587534640ab84596faaf47bce-d61babbe-826f-4152-b835-218f3c.fly.dev'
+  ],
   images: {
     unoptimized: true,
     domains: [

--- a/truffle-clone/src/app/api/brochure-images/route.ts
+++ b/truffle-clone/src/app/api/brochure-images/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import fs from 'node:fs'
 import path from 'node:path'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
 
 const BROCHURE_DIR = path.join(process.cwd(), 'public', 'brochure')
 

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -7,62 +7,6 @@ const GOOGLE_TRANSLATE_ENDPOINT = 'https://translate.googleapis.com/translate_a/
 const MAX_TRANSLATION_RETRIES = 2
 const MAX_PARALLEL_TRANSLATIONS = 8
 
-const CTA_TRANSLATION_OVERRIDES: Partial<Record<Language, Record<string, string>>> = {
-  th: {
-    'See All Villa Types': 'ดูวิลล่าทุกประเภท',
-    'View Brochure': 'ดูโบรชัวร์'
-  },
-  'zh-CN': {
-    'See All Villa Types': '查看所有别墅类型',
-    'View Brochure': '查看宣传册'
-  },
-  'zh-TW': {
-    'See All Villa Types': '查看所有別墅類型',
-    'View Brochure': '查看型錄'
-  },
-  ja: {
-    'See All Villa Types': 'すべてのヴィラタイプを見る',
-    'View Brochure': 'パンフレットを見る'
-  },
-  ko: {
-    'See All Villa Types': '모든 빌라 유형 보기',
-    'View Brochure': '브로셔 보기'
-  },
-  ar: {
-    'See All Villa Types': 'عرض جميع أنواع الفلل',
-    'View Brochure': 'عرض الكتيب'
-  },
-  hi: {
-    'See All Villa Types': 'सभी विला प्रकार देखें',
-    'View Brochure': 'ब्रोशर देखें'
-  },
-  ru: {
-    'See All Villa Types': 'Посмотреть все типы вилл',
-    'View Brochure': 'Посмотреть брошюру'
-  },
-  es: {
-    'See All Villa Types': 'Ver todos los tipos de villas',
-    'View Brochure': 'Ver folleto'
-  },
-  fr: {
-    'See All Villa Types': 'Voir tous les types de villa',
-    'View Brochure': 'Voir la brochure'
-  },
-  ms: {
-    'See All Villa Types': 'Lihat semua jenis vila',
-    'View Brochure': 'Lihat risalah'
-  },
-  vi: {
-    'See All Villa Types': 'Xem tất cả các loại biệt thự',
-    'View Brochure': 'Xem tờ giới thiệu'
-  }
-}
-
-const getOverrideTranslation = (language: Language, text: string): string | null => {
-  const overrides = CTA_TRANSLATION_OVERRIDES[language]
-  return overrides?.[text] ?? null
-}
-
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 
 interface TranslationRequestPayload {

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -61,6 +61,7 @@ const getOverrideTranslation = (language: Language, text: string): string | null
   const overrides = CTA_TRANSLATION_OVERRIDES[language]
   return overrides?.[text] ?? null
 }
+
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 
 interface TranslationRequestPayload {

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -188,7 +188,7 @@ export async function POST(request: Request) {
     const translatedMap = await translateUniqueTexts(uniqueTexts, normalizedLanguage)
 
     for (const [text, indexes] of indexMap.entries()) {
-      const manual = getOverrideTranslation(normalizedLanguage, text)
+      const manual = getCtaOverrideForText(normalizedLanguage, text)
       const translated = manual ?? translatedMap.get(text) ?? text
       indexes.forEach(position => {
         translations[position] = translated

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { Language } from '@/lib/translations'
 import { DEFAULT_LANGUAGE, supportedLanguages } from '@/lib/translations'
+import { getCtaOverrideForText } from '@/lib/ctaOverrides'
 
 const GOOGLE_TRANSLATE_ENDPOINT = 'https://translate.googleapis.com/translate_a/single'
 const MAX_TRANSLATION_RETRIES = 2

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -87,7 +87,7 @@ const getLanguageCache = (language: Language): Map<string, string> => {
 
 const translateTextWithCache = async (text: string, language: Language): Promise<string> => {
   const cache = getLanguageCache(language)
-  const override = getOverrideTranslation(language, text)
+  const override = getCtaOverrideForText(language, text)
   if (override) {
     cache.set(text, override)
     return override

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -6,6 +6,61 @@ const GOOGLE_TRANSLATE_ENDPOINT = 'https://translate.googleapis.com/translate_a/
 const MAX_TRANSLATION_RETRIES = 2
 const MAX_PARALLEL_TRANSLATIONS = 8
 
+const CTA_TRANSLATION_OVERRIDES: Partial<Record<Language, Record<string, string>>> = {
+  th: {
+    'See All Villa Types': 'ดูวิลล่าทุกประเภท',
+    'View Brochure': 'ดูโบรชัวร์'
+  },
+  'zh-CN': {
+    'See All Villa Types': '查看所有别墅类型',
+    'View Brochure': '查看宣传册'
+  },
+  'zh-TW': {
+    'See All Villa Types': '查看所有別墅類型',
+    'View Brochure': '查看型錄'
+  },
+  ja: {
+    'See All Villa Types': 'すべてのヴィラタイプを見る',
+    'View Brochure': 'パンフレットを見る'
+  },
+  ko: {
+    'See All Villa Types': '모든 빌라 유형 보기',
+    'View Brochure': '브로셔 보기'
+  },
+  ar: {
+    'See All Villa Types': 'عرض جميع أنواع الفلل',
+    'View Brochure': 'عرض الكتيب'
+  },
+  hi: {
+    'See All Villa Types': 'सभी विला प्रकार देखें',
+    'View Brochure': 'ब्रोशर देखें'
+  },
+  ru: {
+    'See All Villa Types': 'Посмотреть все типы вилл',
+    'View Brochure': 'Посмотреть брошюру'
+  },
+  es: {
+    'See All Villa Types': 'Ver todos los tipos de villas',
+    'View Brochure': 'Ver folleto'
+  },
+  fr: {
+    'See All Villa Types': 'Voir tous les types de villa',
+    'View Brochure': 'Voir la brochure'
+  },
+  ms: {
+    'See All Villa Types': 'Lihat semua jenis vila',
+    'View Brochure': 'Lihat risalah'
+  },
+  vi: {
+    'See All Villa Types': 'Xem tất cả các loại biệt thự',
+    'View Brochure': 'Xem tờ giới thiệu'
+  }
+}
+
+const getOverrideTranslation = (language: Language, text: string): string | null => {
+  const overrides = CTA_TRANSLATION_OVERRIDES[language]
+  return overrides?.[text] ?? null
+}
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 
 interface TranslationRequestPayload {
@@ -86,6 +141,12 @@ const getLanguageCache = (language: Language): Map<string, string> => {
 
 const translateTextWithCache = async (text: string, language: Language): Promise<string> => {
   const cache = getLanguageCache(language)
+  const override = getOverrideTranslation(language, text)
+  if (override) {
+    cache.set(text, override)
+    return override
+  }
+
   const cached = cache.get(text)
   if (cached !== undefined) {
     return cached
@@ -181,7 +242,8 @@ export async function POST(request: Request) {
     const translatedMap = await translateUniqueTexts(uniqueTexts, normalizedLanguage)
 
     for (const [text, indexes] of indexMap.entries()) {
-      const translated = translatedMap.get(text) ?? text
+      const manual = getOverrideTranslation(normalizedLanguage, text)
+      const translated = manual ?? translatedMap.get(text) ?? text
       indexes.forEach(position => {
         translations[position] = translated
       })

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -6,6 +6,7 @@ import { getCtaOverrideForText, getCtaOverridesSignature } from '@/lib/ctaOverri
 const GOOGLE_TRANSLATE_ENDPOINT = 'https://translate.googleapis.com/translate_a/single'
 const MAX_TRANSLATION_RETRIES = 2
 const MAX_PARALLEL_TRANSLATIONS = 8
+const CTA_SIGNATURE = getCtaOverridesSignature()
 
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 

--- a/truffle-clone/src/app/api/translate/route.ts
+++ b/truffle-clone/src/app/api/translate/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { Language } from '@/lib/translations'
 import { DEFAULT_LANGUAGE, supportedLanguages } from '@/lib/translations'
-import { getCtaOverrideForText } from '@/lib/ctaOverrides'
+import { getCtaOverrideForText, getCtaOverridesSignature } from '@/lib/ctaOverrides'
 
 const GOOGLE_TRANSLATE_ENDPOINT = 'https://translate.googleapis.com/translate_a/single'
 const MAX_TRANSLATION_RETRIES = 2

--- a/truffle-clone/src/app/layout.tsx
+++ b/truffle-clone/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import ClientBody from "./ClientBody";
@@ -17,7 +18,13 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Marnfah Pool Villas - Luxury Villas in Pattaya",
   description: "Live peacefully in Pattaya's most prestigious estate. Timeless design with unrivaled quality and passion for perfection.",
-  viewport: "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: "no",
 };
 
 export default function RootLayout({

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -98,15 +98,15 @@ export default function MapPage() {
   const googleMapCard = (
     <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/30 backdrop-blur-sm aspect-[1980/1488]">
       <iframe
-        src="https://maps.google.com/maps?q=Pattaya%20Thailand&z=12&output=embed"
-        title="Pattaya Map"
+        src={mapEmbedSrc}
+        title="Marnfah Pool Villas Location"
         className="absolute inset-0 w-full h-full"
         loading="lazy"
         allowFullScreen
         referrerPolicy="no-referrer-when-downgrade"
       />
       <div className="absolute top-4 right-4 bg-white/80 backdrop-blur-md rounded-xl px-4 py-2 text-[#264f28] shadow-lg">
-        <span className="text-sm font-medium">12.8°N, 100.9°E</span>
+        <span className="text-sm font-medium">{mapLocation.display}</span>
       </div>
     </div>
   )

--- a/truffle-clone/src/app/map/page.tsx
+++ b/truffle-clone/src/app/map/page.tsx
@@ -76,6 +76,14 @@ export default function MapPage() {
   const [mapAdjacentHighlight, ...secondaryHighlights] = otherHighlights
   const isSingleSecondaryHighlight = secondaryHighlights.length === 1
 
+  const mapLocation = {
+    lat: 12.888972,
+    lng: 100.949889,
+    display: '12°53\'20.3"N 100°56\'59.6"E'
+  }
+  const mapZoom = 16
+  const mapEmbedSrc = `https://maps.google.com/maps?q=${mapLocation.lat},${mapLocation.lng}&z=${mapZoom}&output=embed`
+
   const staticMapCard = (
     <div className="relative rounded-3xl overflow-hidden border-8 border-[#b48828]/30 shadow-2xl bg-white/10 backdrop-blur-sm">
       <img

--- a/truffle-clone/src/components/BrochureButton.tsx
+++ b/truffle-clone/src/components/BrochureButton.tsx
@@ -26,7 +26,7 @@ export default function BrochureButton({ children, className }: BrochureButtonPr
       )}
     >
       <span className="inline-flex items-center gap-2">
-        View {children}
+        {children}
         <span aria-hidden="true">↗</span>
       </span>
     </button>

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -307,7 +307,7 @@ export default function Navigation() {
               {/* Language Dropdown Menu - Desktop Only */}
               {isLanguageDropdownOpen && (
                 <div
-                  className="absolute top-full mt-2 left-0 rounded-xl border border-[#b48828]/20 bg-[#b48828]/60 shadow-2xl overflow-hidden z-[99999]"
+                  className="absolute top-full mt-2 right-0 rounded-xl border border-[#b48828]/20 bg-[#b48828]/60 shadow-2xl overflow-hidden z-[99999]"
                   style={{ minWidth: '70px' }}
                 >
                   <div className="p-1">

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -278,7 +278,7 @@ export default function Navigation() {
           </div>
 
           {/* Desktop language menu - moved further right */}
-          <div className="hidden md:flex items-center gap-4 transform md:-translate-x-6 lg:-translate-x-8 xl:-translate-x-10">
+          <div className="hidden md:flex items-center gap-4 transform md:translate-x-6 lg:translate-x-8 xl:translate-x-10">
             <div className="relative" ref={desktopLanguageDropdownRef}>
               <button
                 onClick={() => {

--- a/truffle-clone/src/components/Navigation.tsx
+++ b/truffle-clone/src/components/Navigation.tsx
@@ -46,7 +46,7 @@ export default function Navigation() {
     {
       key: 'line',
       label: t.footer.line,
-      href: 'https://line.me/ti/p/MarnfahPoolVillas',
+      href: 'https://lin.ee/xK6xWUi',
       imgSrc: 'https://cdn.builder.io/api/v1/image/assets%2Fea91dcb877424cffabd32075be7aafd0%2F9487ed1d900b4348834f3adb2824e1e9?format=webp&width=800'
     }
   ] as const

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -136,7 +136,7 @@ export default function PropertiesSection() {
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
-                    See All Villa Types
+                    {t.properties.seeAllVillaTypes}
                     <span aria-hidden="true">↗</span>
                   </span>
                 </Link>

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -3,9 +3,13 @@
 import Link from 'next/link'
 import BrochureButton from '@/components/BrochureButton'
 import { useTranslation } from '@/lib/useTranslation'
+import { getCtaOverride } from '@/lib/ctaOverrides'
 
 export default function PropertiesSection() {
-  const { t } = useTranslation()
+  const { t, language } = useTranslation()
+  const ctaOverride = getCtaOverride(language)
+  const seeAllVillaTypesText = ctaOverride?.seeAllVillaTypes ?? t.properties.seeAllVillaTypes
+  const brochureButtonText = ctaOverride?.viewBrochure ?? t.exclusive.buttonText
 
   return (
     <div className="w-full villa-section-no-scroll">

--- a/truffle-clone/src/components/PropertiesSection.tsx
+++ b/truffle-clone/src/components/PropertiesSection.tsx
@@ -140,12 +140,12 @@ export default function PropertiesSection() {
                   className="inline-flex items-center justify-center px-10 md:px-12 py-3 md:py-3.5 min-w-[11rem] rounded-2xl bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 transition-all duration-300 whitespace-nowrap hover:bg-[#264f28]/20 hover:border-[#264f28]/40 hover:scale-105 text-base md:text-lg font-normal mt-[0.25cm] md:mt-[0.25cm] lg:mt-0"
                 >
                   <span className="inline-flex items-center gap-2">
-                    {t.properties.seeAllVillaTypes}
+                    {seeAllVillaTypesText}
                     <span aria-hidden="true">↗</span>
                   </span>
                 </Link>
                 <BrochureButton className="font-normal min-w-[11rem]">
-                  {t.exclusive.buttonText}
+                  {brochureButtonText}
                 </BrochureButton>
               </div>
           </div>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -118,7 +118,7 @@ export default function VirtualTourSection() {
                     <div className="flex flex-col gap-1">
                       <h3 className="text-xl font-semibold">{villa.name}</h3>
                       {villaDetails[villa.id] && (
-                        <p className="text-white/90 text-sm md:text-base pb-1 relative">
+                        <p className="text-white/90 text-sm pb-1 relative">
                           {villaDetails[villa.id]}
                           <span
                             className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -102,7 +102,7 @@ export default function VirtualTourSection() {
       </div>
 
       {/* Villa Tour Selection */}
-      <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden sm:overflow-visible">
+      <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden lg:overflow-visible">
         {villas.map((villa, index) => (
           <div key={`${villa.id}-${index}`} className="relative overflow-hidden">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -88,7 +88,7 @@ export default function VirtualTourSection() {
             </svg>
           </div>
           <div className="relative mb-4">
-            <h1 className="text-3xl md:text-6xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
+            <h1 className="text-3xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
               <span className="relative inline-block">
                 <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm"></span>
                 <span className="relative bg-gradient-to-r from-[#264f28] to-[#2d5a30] bg-clip-text text-transparent font-medium">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -163,7 +163,7 @@ export default function VirtualTourSection() {
                   </div>
                   <button
                     type="button"
-                    className="text-xs md:text-sm font-medium bg-white/10 hover:bg-white/20 text-white px-3 md:px-4 py-1 md:py-1.5 rounded-full border border-white/30 transition-colors"
+                    className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
                   >
                     View Pictures ↗
                   </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -88,7 +88,7 @@ export default function VirtualTourSection() {
             </svg>
           </div>
           <div className="relative mb-4">
-            <h1 className="text-3xl md:text-5xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
+            <h1 className="text-3xl md:text-6xl lg:text-6xl font-light italic text-[#264f28] tracking-wide leading-tight">
               <span className="relative inline-block">
                 <span className="absolute -inset-2 bg-gradient-to-r from-[#264f28]/20 via-[#264f28]/10 to-transparent rounded-2xl blur-sm"></span>
                 <span className="relative bg-gradient-to-r from-[#264f28] to-[#2d5a30] bg-clip-text text-transparent font-medium">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -269,7 +269,7 @@ export default function VirtualTourSection() {
                     <button className="w-full bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 rounded-xl px-4 py-2 text-sm md:text-base hover:bg-[#b48828]/20 transition-colors">
                       Full Screen Mode
                     </button>
-                    <button className="w-full bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 rounded-xl px-4 py-2 text-sm hover:bg-[#264f28]/20 transition-colors">
+                    <button className="w-full bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 rounded-xl px-4 py-2 text-sm md:text-base hover:bg-[#264f28]/20 transition-colors">
                       Schedule Physical Tour
                     </button>
                   </div>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -106,7 +106,7 @@ export default function VirtualTourSection() {
         {villas.map((villa, index) => (
           <div key={`${villa.id}-${index}`} className="relative overflow-hidden">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-              <div className="relative h-64 sm:h-64 overflow-hidden">
+              <div className="relative h-64 lg:h-[520px] overflow-hidden">
                 <img
                   src={villa.image}
                   alt={villa.name}
@@ -142,7 +142,7 @@ export default function VirtualTourSection() {
         ))}
         <div className="relative overflow-hidden">
           <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-            <div className="relative h-64 sm:h-64 overflow-hidden">
+            <div className="relative h-64 lg:h-[520px] overflow-hidden">
               <img
                 src={villas[0].image}
                 alt="Villa Type 4"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -129,7 +129,7 @@ export default function VirtualTourSection() {
                     </div>
                     <button
                       type="button"
-                      className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                      className="text-xs md:text-sm font-medium bg-white/10 hover:bg-white/20 text-white px-3 md:px-4 py-1 md:py-1.5 rounded-full border border-white/30 transition-colors"
                     >
                       View Pictures ↗
                     </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -163,7 +163,7 @@ export default function VirtualTourSection() {
                   </div>
                   <button
                     type="button"
-                    className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
+                    className="text-xs md:text-sm font-medium bg-white/10 hover:bg-white/20 text-white px-3 md:px-4 py-1 md:py-1.5 rounded-full border border-white/30 transition-colors"
                   >
                     View Pictures ↗
                   </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -238,7 +238,7 @@ export default function VirtualTourSection() {
               {/* Room Navigation Sidebar */}
               <div className="absolute right-0 top-0 bottom-0 w-80 bg-white/95 backdrop-blur-sm border-l border-gray-200 p-6 overflow-y-auto">
                 <h4 className="text-lg font-semibold text-[#264f28] mb-4">Room Navigation</h4>
-                <div className="space-y-3">
+                <div className="space-y-3 md:space-y-4">
                   {selectedVillaData.rooms.map((room, index) => (
                     <button
                       key={index}

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -104,9 +104,9 @@ export default function VirtualTourSection() {
       {/* Villa Tour Selection */}
       <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden sm:overflow-visible">
         {villas.map((villa, index) => (
-          <div key={`${villa.id}-${index}`} className="relative overflow-hidden sm:overflow-visible">
+          <div key={`${villa.id}-${index}`} className="relative overflow-hidden">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-              <div className="relative h-64 sm:h-[520px] overflow-hidden">
+              <div className="relative h-64 sm:h-64 overflow-hidden">
                 <img
                   src={villa.image}
                   alt={villa.name}
@@ -140,9 +140,9 @@ export default function VirtualTourSection() {
             </div>
           </div>
         ))}
-        <div className="relative overflow-hidden sm:overflow-visible">
+        <div className="relative overflow-hidden">
           <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-            <div className="relative h-64 sm:h-[520px] overflow-hidden">
+            <div className="relative h-64 sm:h-64 overflow-hidden">
               <img
                 src={villas[0].image}
                 alt="Villa Type 4"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -266,7 +266,7 @@ export default function VirtualTourSection() {
                 <div className="mt-8 pt-6 border-t border-gray-200">
                   <h5 className="text-sm font-medium text-[#264f28] mb-3">Tour Controls</h5>
                   <div className="space-y-3 md:space-y-4">
-                    <button className="w-full bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 rounded-xl px-4 py-2 text-sm hover:bg-[#b48828]/20 transition-colors">
+                    <button className="w-full bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 rounded-xl px-4 py-2 text-sm md:text-base hover:bg-[#b48828]/20 transition-colors">
                       Full Screen Mode
                     </button>
                     <button className="w-full bg-[#264f28]/10 text-[#264f28] border border-[#264f28]/20 rounded-xl px-4 py-2 text-sm hover:bg-[#264f28]/20 transition-colors">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -106,7 +106,7 @@ export default function VirtualTourSection() {
         {villas.map((villa, index) => (
           <div key={`${villa.id}-${index}`} className="relative overflow-hidden sm:overflow-visible">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-              <div className="relative h-64 md:h-[520px] lg:h-[520px] overflow-hidden">
+              <div className="relative h-64 sm:h-[520px] overflow-hidden">
                 <img
                   src={villa.image}
                   alt={villa.name}
@@ -142,7 +142,7 @@ export default function VirtualTourSection() {
         ))}
         <div className="relative overflow-hidden sm:overflow-visible">
           <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-            <div className="relative h-64 md:h-[520px] lg:h-[520px] overflow-hidden">
+            <div className="relative h-64 sm:h-[520px] overflow-hidden">
               <img
                 src={villas[0].image}
                 alt="Villa Type 4"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -265,7 +265,7 @@ export default function VirtualTourSection() {
                 {/* Tour Controls */}
                 <div className="mt-8 pt-6 border-t border-gray-200">
                   <h5 className="text-sm font-medium text-[#264f28] mb-3">Tour Controls</h5>
-                  <div className="space-y-3">
+                  <div className="space-y-3 md:space-y-4">
                     <button className="w-full bg-[#b48828]/10 text-[#b48828] border border-[#b48828]/20 rounded-xl px-4 py-2 text-sm hover:bg-[#b48828]/20 transition-colors">
                       Full Screen Mode
                     </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -153,7 +153,7 @@ export default function VirtualTourSection() {
                 <div className="flex items-end justify-between gap-3 text-left">
                   <div className="flex flex-col gap-1">
                     <h3 className="text-xl font-semibold">Villa Type 4</h3>
-                    <p className="text-white/90 text-sm md:text-base pb-1 relative">
+                    <p className="text-white/90 text-sm pb-1 relative">
                       4 Bed - 5 Bath - 353 sqm.
                       <span
                         className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -104,13 +104,13 @@ export default function VirtualTourSection() {
       {/* Villa Tour Selection */}
       <div className="grid grid-cols-1 lg:grid-cols-1 gap-8 overflow-hidden sm:overflow-visible">
         {villas.map((villa, index) => (
-          <div key={`${villa.id}-${index}`} className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
-            <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden transition-all duration-300 sm:group-hover:scale-[1.02]">
-              <div className="relative h-64 overflow-hidden">
+          <div key={`${villa.id}-${index}`} className="relative overflow-hidden sm:overflow-visible">
+            <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
+              <div className="relative h-64 md:h-auto overflow-hidden" style={{ aspectRatio: '375 / 256' }}>
                 <img
                   src={villa.image}
                   alt={villa.name}
-                  className="w-full h-full object-cover transition-transform duration-300 sm:group-hover:scale-110"
+                  className="w-full h-full object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                 <div className="absolute bottom-4 left-4 right-4 text-white">
@@ -140,13 +140,13 @@ export default function VirtualTourSection() {
             </div>
           </div>
         ))}
-        <div className="group cursor-pointer relative overflow-hidden sm:overflow-visible">
-          <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden transition-all duration-300 sm:group-hover:scale-[1.02]">
-            <div className="relative h-64 overflow-hidden">
+        <div className="relative overflow-hidden sm:overflow-visible">
+          <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
+            <div className="relative h-64 md:h-auto overflow-hidden" style={{ aspectRatio: '375 / 256' }}>
               <img
                 src={villas[0].image}
                 alt="Villa Type 4"
-                className="w-full h-full object-cover transition-transform duration-300 sm:group-hover:scale-110"
+                className="w-full h-full object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
               <div className="absolute bottom-4 left-4 right-4 text-white">

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -153,7 +153,7 @@ export default function VirtualTourSection() {
                 <div className="flex items-end justify-between gap-3 text-left">
                   <div className="flex flex-col gap-1">
                     <h3 className="text-xl font-semibold">Villa Type 4</h3>
-                    <p className="text-white/90 text-sm lg:text-base pb-1 relative">
+                    <p className="text-white/90 text-sm md:text-base pb-1 relative">
                       4 Bed - 5 Bath - 353 sqm.
                       <span
                         className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -129,7 +129,7 @@ export default function VirtualTourSection() {
                     </div>
                     <button
                       type="button"
-                      className="text-xs md:text-sm font-medium bg-white/10 hover:bg-white/20 text-white px-3 md:px-4 py-1 md:py-1.5 rounded-full border border-white/30 transition-colors"
+                      className="text-xs font-medium bg-white/10 hover:bg-white/20 text-white px-3 py-1 rounded-full border border-white/30 transition-colors"
                     >
                       View Pictures ↗
                     </button>

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -118,7 +118,7 @@ export default function VirtualTourSection() {
                     <div className="flex flex-col gap-1">
                       <h3 className="text-xl font-semibold">{villa.name}</h3>
                       {villaDetails[villa.id] && (
-                        <p className="text-white/90 text-sm lg:text-base pb-1 relative">
+                        <p className="text-white/90 text-sm md:text-base pb-1 relative">
                           {villaDetails[villa.id]}
                           <span
                             className="absolute bottom-0 left-0 right-0 h-[0.5px] bg-gradient-to-r from-transparent via-white/40 to-transparent"

--- a/truffle-clone/src/components/VirtualTourSection.tsx
+++ b/truffle-clone/src/components/VirtualTourSection.tsx
@@ -106,7 +106,7 @@ export default function VirtualTourSection() {
         {villas.map((villa, index) => (
           <div key={`${villa.id}-${index}`} className="relative overflow-hidden sm:overflow-visible">
             <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-              <div className="relative h-64 md:h-auto overflow-hidden" style={{ aspectRatio: '375 / 256' }}>
+              <div className="relative h-64 md:h-[520px] lg:h-[520px] overflow-hidden">
                 <img
                   src={villa.image}
                   alt={villa.name}
@@ -142,7 +142,7 @@ export default function VirtualTourSection() {
         ))}
         <div className="relative overflow-hidden sm:overflow-visible">
           <div className="bg-white/90 backdrop-blur-sm rounded-3xl border-8 border-[#b48828]/30 overflow-hidden">
-            <div className="relative h-64 md:h-auto overflow-hidden" style={{ aspectRatio: '375 / 256' }}>
+            <div className="relative h-64 md:h-[520px] lg:h-[520px] overflow-hidden">
               <img
                 src={villas[0].image}
                 alt="Villa Type 4"

--- a/truffle-clone/src/lib/ctaOverrides.ts
+++ b/truffle-clone/src/lib/ctaOverrides.ts
@@ -14,7 +14,7 @@ export interface CtaOverride {
 const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
   th: {
     seeAllVillaTypes: 'ดูวิลล่าทุกประเภท',
-    viewBrochure: '��ูโบรชัวร์'
+    viewBrochure: 'ดูโบรชัวร์'
   },
   'zh-CN': {
     seeAllVillaTypes: '查看所有别墅类型',

--- a/truffle-clone/src/lib/ctaOverrides.ts
+++ b/truffle-clone/src/lib/ctaOverrides.ts
@@ -1,0 +1,76 @@
+import type { Language, Translations } from '@/lib/translations'
+import { DEFAULT_LANGUAGE } from '@/lib/translations'
+
+export interface CtaOverride {
+  seeAllVillaTypes: string
+  viewBrochure: string
+}
+
+const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
+  th: {
+    seeAllVillaTypes: 'ดูวิลล่าทุกประเภท',
+    viewBrochure: 'ดูโบรชัวร์'
+  },
+  'zh-CN': {
+    seeAllVillaTypes: '查看所有别墅类型',
+    viewBrochure: '查看宣传册'
+  },
+  'zh-TW': {
+    seeAllVillaTypes: '查看所有別墅類型',
+    viewBrochure: '查看型錄'
+  },
+  ja: {
+    seeAllVillaTypes: 'すべてのヴィラタイプを見る',
+    viewBrochure: 'パンフレットを見る'
+  },
+  ko: {
+    seeAllVillaTypes: '모든 빌라 유형 보기',
+    viewBrochure: '브��셔 보기'
+  },
+  ar: {
+    seeAllVillaTypes: 'عرض جميع أنواع الفلل',
+    viewBrochure: 'عرض الكتيب'
+  },
+  hi: {
+    seeAllVillaTypes: 'सभी विला प्रकार देखें',
+    viewBrochure: 'ब्रोशर देखें'
+  },
+  ru: {
+    seeAllVillaTypes: 'Посмотреть все типы вилл',
+    viewBrochure: 'Посмотреть брошюру'
+  },
+  es: {
+    seeAllVillaTypes: 'Ver todos los tipos de villas',
+    viewBrochure: 'Ver folleto'
+  },
+  fr: {
+    seeAllVillaTypes: 'Voir tous les types de villa',
+    viewBrochure: 'Voir la brochure'
+  },
+  ms: {
+    seeAllVillaTypes: 'Lihat semua jenis vila',
+    viewBrochure: 'Lihat risalah'
+  },
+  vi: {
+    seeAllVillaTypes: 'Xem tất cả các loại biệt thự',
+    viewBrochure: 'Xem tờ giới thiệu'
+  }
+}
+
+export const getCtaOverride = (language: Language): CtaOverride | null => {
+  return CTA_OVERRIDES[language] ?? null
+}
+
+export const applyCtaOverrideToTranslations = (language: Language, translations: Translations) => {
+  if (language === DEFAULT_LANGUAGE) {
+    return
+  }
+
+  const override = getCtaOverride(language)
+  if (!override) {
+    return
+  }
+
+  translations.properties.seeAllVillaTypes = override.seeAllVillaTypes
+  translations.exclusive.buttonText = override.viewBrochure
+}

--- a/truffle-clone/src/lib/ctaOverrides.ts
+++ b/truffle-clone/src/lib/ctaOverrides.ts
@@ -1,6 +1,11 @@
 import type { Language, Translations } from '@/lib/translations'
 import { DEFAULT_LANGUAGE } from '@/lib/translations'
 
+export const CTA_SOURCE_TEXTS = {
+  seeAllVillaTypes: 'See All Villa Types',
+  viewBrochure: 'View Brochure'
+} as const
+
 export interface CtaOverride {
   seeAllVillaTypes: string
   viewBrochure: string
@@ -9,7 +14,7 @@ export interface CtaOverride {
 const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
   th: {
     seeAllVillaTypes: 'ดูวิลล่าทุกประเภท',
-    viewBrochure: 'ดูโบรชัวร์'
+    viewBrochure: '��ูโบรชัวร์'
   },
   'zh-CN': {
     seeAllVillaTypes: '查看所有别墅类型',
@@ -25,7 +30,7 @@ const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
   },
   ko: {
     seeAllVillaTypes: '모든 빌라 유형 보기',
-    viewBrochure: '브��셔 보기'
+    viewBrochure: '브로셔 보기'
   },
   ar: {
     seeAllVillaTypes: 'عرض جميع أنواع الفلل',
@@ -59,6 +64,23 @@ const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
 
 export const getCtaOverride = (language: Language): CtaOverride | null => {
   return CTA_OVERRIDES[language] ?? null
+}
+
+export const getCtaOverrideForText = (language: Language, sourceText: string): string | null => {
+  const override = getCtaOverride(language)
+  if (!override) {
+    return null
+  }
+
+  if (sourceText === CTA_SOURCE_TEXTS.seeAllVillaTypes) {
+    return override.seeAllVillaTypes
+  }
+
+  if (sourceText === CTA_SOURCE_TEXTS.viewBrochure) {
+    return override.viewBrochure
+  }
+
+  return null
 }
 
 export const applyCtaOverrideToTranslations = (language: Language, translations: Translations) => {

--- a/truffle-clone/src/lib/ctaOverrides.ts
+++ b/truffle-clone/src/lib/ctaOverrides.ts
@@ -62,6 +62,19 @@ const CTA_OVERRIDES: Partial<Record<Language, CtaOverride>> = {
   }
 }
 
+const CTA_OVERRIDES_SIGNATURE = (() => {
+  const entries = Object.entries(CTA_OVERRIDES).map(([language, override]) => {
+    if (!override) {
+      return `${language}::`
+    }
+    return `${language}:${override.seeAllVillaTypes}|${override.viewBrochure}`
+  })
+  entries.sort()
+  return entries.join('||')
+})()
+
+export const getCtaOverridesSignature = (): string => CTA_OVERRIDES_SIGNATURE
+
 export const getCtaOverride = (language: Language): CtaOverride | null => {
   return CTA_OVERRIDES[language] ?? null
 }

--- a/truffle-clone/src/lib/translations.ts
+++ b/truffle-clone/src/lib/translations.ts
@@ -35,6 +35,7 @@ const englishTranslationsData = {
   properties: {
     title: "Supreme Elegance",
     description: "Experience tropical opulence\nWarm wood and Italian stone accents\nLimited availability from ฿10.9M to ฿34.9M",
+    seeAllVillaTypes: "See All Villa Types",
     priceRange: "",
     villa1: {
       name: "Tranquility",
@@ -71,7 +72,7 @@ const englishTranslationsData = {
   exclusive: {
     title: "Bespoke Lifestyle",
     description: "For those who love the finer things\nCrafted with immense attention to detail\nShaped to enhance the flow of positive energy",
-    buttonText: "Brochure"
+    buttonText: "View Brochure"
   },
   location: {
     title: "Located in Paradise",

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -93,7 +93,7 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'es', name: 'Español', currency: '🇪🇸' },
   { code: 'fr', name: 'Français', currency: '🇫🇷' },
   { code: 'ms', name: 'Malay', currency: '🇲🇾' },
-  { code: 'vi', name: 'Tiếng Việt', currency: '��🇳' }
+  { code: 'vi', name: 'Tiếng Việt', currency: '🇻🇳' }
 ]
 
 interface TranslationContextType {

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -80,7 +80,7 @@ const detectBrowserLanguage = (): Language => {
 export const languageInfo: Array<{ code: Language; name: string; currency: string }> = [
   { code: 'th', name: 'ไทย', currency: '🇹🇭' },
   { code: 'zh-CN', name: '简体中文', currency: '🇨🇳' },
-  { code: 'zh-TW', name: '繁體中文', currency: '🇹🇼' },
+  { code: 'zh-TW', name: '繁體中���', currency: '🇹🇼' },
   { code: 'ja', name: '日本語', currency: '🇯🇵' },
   { code: 'ko', name: '한국어', currency: '🇰🇷' },
   { code: 'ar', name: 'العربية', currency: '🇸🇦' },
@@ -92,81 +92,6 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'ms', name: 'Malay', currency: '🇲🇾' },
   { code: 'vi', name: 'Tiếng Việt', currency: '🇻🇳' }
 ]
-
-interface CtaOverrides {
-  seeAllVillaTypes?: string
-  viewBrochure?: string
-}
-
-const CTA_OVERRIDES: Partial<Record<Language, CtaOverrides>> = {
-  th: {
-    seeAllVillaTypes: 'ดูวิลล่าทุกประเภท',
-    viewBrochure: 'ดูโบรชัวร์'
-  },
-  'zh-CN': {
-    seeAllVillaTypes: '查看所有别墅类型',
-    viewBrochure: '查看宣传册'
-  },
-  'zh-TW': {
-    seeAllVillaTypes: '查看所有別墅類型',
-    viewBrochure: '查看型錄'
-  },
-  ja: {
-    seeAllVillaTypes: 'すべてのヴィラタイプを見る',
-    viewBrochure: 'パンフレットを見る'
-  },
-  ko: {
-    seeAllVillaTypes: '모든 빌라 유형 보기',
-    viewBrochure: '브로셔 보기'
-  },
-  ar: {
-    seeAllVillaTypes: 'عرض جميع أنواع الفلل',
-    viewBrochure: 'عرض الكتيب'
-  },
-  hi: {
-    seeAllVillaTypes: 'सभी विल�� प्रकार देखें',
-    viewBrochure: 'ब्रोशर देखें'
-  },
-  ru: {
-    seeAllVillaTypes: 'Посмотреть все типы вилл',
-    viewBrochure: 'Посмотреть брошюру'
-  },
-  es: {
-    seeAllVillaTypes: 'Ver todos los tipos de villas',
-    viewBrochure: 'Ver folleto'
-  },
-  fr: {
-    seeAllVillaTypes: 'Voir tous les types de villa',
-    viewBrochure: 'Voir la brochure'
-  },
-  ms: {
-    seeAllVillaTypes: 'Lihat semua jenis vila',
-    viewBrochure: 'Lihat risalah'
-  },
-  vi: {
-    seeAllVillaTypes: 'Xem tất cả các loại biệt thự',
-    viewBrochure: 'Xem tờ giới thiệu'
-  }
-}
-
-const applyCtaOverrides = (language: Language, translations: Translations) => {
-  if (language === DEFAULT_LANGUAGE) {
-    return
-  }
-
-  const overrides = CTA_OVERRIDES[language]
-  if (!overrides) {
-    return
-  }
-
-  if (overrides.seeAllVillaTypes) {
-    translations.properties.seeAllVillaTypes = overrides.seeAllVillaTypes
-  }
-
-  if (overrides.viewBrochure) {
-    translations.exclusive.buttonText = overrides.viewBrochure
-  }
-}
 
 interface TranslationContextType {
   language: Language

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -92,6 +92,81 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'vi', name: 'Tiếng Việt', currency: '🇻🇳' }
 ]
 
+interface CtaOverrides {
+  seeAllVillaTypes?: string
+  viewBrochure?: string
+}
+
+const CTA_OVERRIDES: Partial<Record<Language, CtaOverrides>> = {
+  th: {
+    seeAllVillaTypes: 'ดูวิลล่าทุกประเภท',
+    viewBrochure: 'ดูโบรชัวร์'
+  },
+  'zh-CN': {
+    seeAllVillaTypes: '查看所有别墅类型',
+    viewBrochure: '查看宣传册'
+  },
+  'zh-TW': {
+    seeAllVillaTypes: '查看所有別墅類型',
+    viewBrochure: '查看型錄'
+  },
+  ja: {
+    seeAllVillaTypes: 'すべてのヴィラタイプを見る',
+    viewBrochure: 'パンフレットを見る'
+  },
+  ko: {
+    seeAllVillaTypes: '모든 빌라 유형 보기',
+    viewBrochure: '브로셔 보기'
+  },
+  ar: {
+    seeAllVillaTypes: 'عرض جميع أنواع الفلل',
+    viewBrochure: 'عرض الكتيب'
+  },
+  hi: {
+    seeAllVillaTypes: 'सभी विला प्रकार देखें',
+    viewBrochure: 'ब्रोशर देखें'
+  },
+  ru: {
+    seeAllVillaTypes: 'Посмотреть все типы вилл',
+    viewBrochure: 'Посмотреть брошюру'
+  },
+  es: {
+    seeAllVillaTypes: 'Ver todos los tipos de villas',
+    viewBrochure: 'Ver folleto'
+  },
+  fr: {
+    seeAllVillaTypes: 'Voir tous les types de villa',
+    viewBrochure: 'Voir la brochure'
+  },
+  ms: {
+    seeAllVillaTypes: 'Lihat semua jenis vila',
+    viewBrochure: 'Lihat risalah'
+  },
+  vi: {
+    seeAllVillaTypes: 'Xem tất cả các loại biệt thự',
+    viewBrochure: 'Xem tờ giới thiệu'
+  }
+}
+
+const applyCtaOverrides = (language: Language, translations: Translations) => {
+  if (language === DEFAULT_LANGUAGE) {
+    return
+  }
+
+  const overrides = CTA_OVERRIDES[language]
+  if (!overrides) {
+    return
+  }
+
+  if (overrides.seeAllVillaTypes) {
+    translations.properties.seeAllVillaTypes = overrides.seeAllVillaTypes
+  }
+
+  if (overrides.viewBrochure) {
+    translations.exclusive.buttonText = overrides.viewBrochure
+  }
+}
+
 interface TranslationContextType {
   language: Language
   setLanguage: (lang: Language) => Promise<void>
@@ -234,6 +309,7 @@ const loadLanguageTranslations = async (language: Language): Promise<Translation
   const cachedStrings = readCachedStrings(language)
   if (cachedStrings) {
     const cachedTranslations = createTranslationsFromStrings(cachedStrings)
+    applyCtaOverrides(language, cachedTranslations)
     setCachedTranslationObject(language, cachedTranslations)
     return cachedTranslations
   }
@@ -241,6 +317,7 @@ const loadLanguageTranslations = async (language: Language): Promise<Translation
   const fetchedStrings = await fetchTranslationsFromApi(language)
   writeCachedStrings(language, fetchedStrings)
   const fetchedTranslations = createTranslationsFromStrings(fetchedStrings)
+  applyCtaOverrides(language, fetchedTranslations)
   setCachedTranslationObject(language, fetchedTranslations)
   return fetchedTranslations
 }

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -16,7 +16,7 @@ import {
   supportedLanguages,
   createTranslationsFromStrings
 } from './translations'
-import { applyCtaOverrideToTranslations } from '@/lib/ctaOverrides'
+import { applyCtaOverrideToTranslations, getCtaOverridesSignature } from '@/lib/ctaOverrides'
 
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 const LANGUAGE_STORAGE_KEY = 'preferred-language'
@@ -83,7 +83,7 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'zh-TW', name: '繁體中文', currency: '🇹🇼' },
   { code: 'ja', name: '日本語', currency: '🇯🇵' },
   { code: 'ko', name: '한국어', currency: '🇰🇷' },
-  { code: 'ar', name: 'العربية', currency: '🇸🇦' },
+  { code: 'ar', name: 'العربية', currency: '����🇦' },
   { code: 'hi', name: 'हिन्दी', currency: '🇮🇳' },
   { code: 'ru', name: 'Русский', currency: '🇷🇺' },
   { code: 'en', name: 'English', currency: '🇺🇸' },

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -80,7 +80,7 @@ const detectBrowserLanguage = (): Language => {
 export const languageInfo: Array<{ code: Language; name: string; currency: string }> = [
   { code: 'th', name: 'ไทย', currency: '🇹🇭' },
   { code: 'zh-CN', name: '简体中文', currency: '🇨🇳' },
-  { code: 'zh-TW', name: '繁體中���', currency: '🇹🇼' },
+  { code: 'zh-TW', name: '繁體中文', currency: '🇹🇼' },
   { code: 'ja', name: '日本語', currency: '🇯🇵' },
   { code: 'ko', name: '한국어', currency: '🇰🇷' },
   { code: 'ar', name: 'العربية', currency: '🇸🇦' },
@@ -235,7 +235,7 @@ const loadLanguageTranslations = async (language: Language): Promise<Translation
   const cachedStrings = readCachedStrings(language)
   if (cachedStrings) {
     const cachedTranslations = createTranslationsFromStrings(cachedStrings)
-    applyCtaOverrides(language, cachedTranslations)
+    applyCtaOverrideToTranslations(language, cachedTranslations)
     setCachedTranslationObject(language, cachedTranslations)
     return cachedTranslations
   }
@@ -243,7 +243,7 @@ const loadLanguageTranslations = async (language: Language): Promise<Translation
   const fetchedStrings = await fetchTranslationsFromApi(language)
   writeCachedStrings(language, fetchedStrings)
   const fetchedTranslations = createTranslationsFromStrings(fetchedStrings)
-  applyCtaOverrides(language, fetchedTranslations)
+  applyCtaOverrideToTranslations(language, fetchedTranslations)
   setCachedTranslationObject(language, fetchedTranslations)
   return fetchedTranslations
 }

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -32,7 +32,10 @@ const computeStringsVersion = (strings: ReadonlyArray<string>): string => {
   return hash.toString(36)
 }
 
-const TRANSLATION_SCHEMA_VERSION = computeStringsVersion(englishTranslationStrings)
+const TRANSLATION_SCHEMA_VERSION = computeStringsVersion([
+  ...englishTranslationStrings,
+  getCtaOverridesSignature()
+])
 const TRANSLATION_CACHE_PREFIX = `translation-cache-${TRANSLATION_SCHEMA_VERSION}-`
 const TRANSLATION_EXPECTED_COUNT = englishTranslationStrings.length
 
@@ -83,7 +86,7 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'zh-TW', name: '繁體中文', currency: '🇹🇼' },
   { code: 'ja', name: '日本語', currency: '🇯🇵' },
   { code: 'ko', name: '한국어', currency: '🇰🇷' },
-  { code: 'ar', name: 'العربية', currency: '����🇦' },
+  { code: 'ar', name: 'العربية', currency: '🇸🇦' },
   { code: 'hi', name: 'हिन्दी', currency: '🇮🇳' },
   { code: 'ru', name: 'Русский', currency: '🇷🇺' },
   { code: 'en', name: 'English', currency: '🇺🇸' },

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -93,7 +93,7 @@ export const languageInfo: Array<{ code: Language; name: string; currency: strin
   { code: 'es', name: 'Español', currency: '🇪🇸' },
   { code: 'fr', name: 'Français', currency: '🇫🇷' },
   { code: 'ms', name: 'Malay', currency: '🇲🇾' },
-  { code: 'vi', name: 'Tiếng Việt', currency: '🇻🇳' }
+  { code: 'vi', name: 'Tiếng Việt', currency: '��🇳' }
 ]
 
 interface TranslationContextType {
@@ -111,7 +111,7 @@ interface TranslationProviderProps {
   children: React.ReactNode
 }
 
-const getCacheKey = (language: Language) => `${TRANSLATION_CACHE_PREFIX}${language}`
+const getCacheKey = (language: Language) => `${TRANSLATION_CACHE_PREFIX}${language}-${getCtaOverridesSignature()}`
 
 const readCachedStrings = (language: Language): string[] | null => {
   if (typeof window === 'undefined') {

--- a/truffle-clone/src/lib/useTranslation.tsx
+++ b/truffle-clone/src/lib/useTranslation.tsx
@@ -16,6 +16,7 @@ import {
   supportedLanguages,
   createTranslationsFromStrings
 } from './translations'
+import { applyCtaOverrideToTranslations } from '@/lib/ctaOverrides'
 
 const SUPPORTED_LANGUAGE_SET = new Set<Language>(supportedLanguages)
 const LANGUAGE_STORAGE_KEY = 'preferred-language'
@@ -123,7 +124,7 @@ const CTA_OVERRIDES: Partial<Record<Language, CtaOverrides>> = {
     viewBrochure: 'عرض الكتيب'
   },
   hi: {
-    seeAllVillaTypes: 'सभी विला प्रकार देखें',
+    seeAllVillaTypes: 'सभी विल�� प्रकार देखें',
     viewBrochure: 'ब्रोशर देखें'
   },
   ru: {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI and functionality issues:
- Repositions the language button in the desktop navigation to match leafy logo spacing (moving it closer to the right edge)
- Implements manual translation overrides for CTA buttons to ensure proper localization
- Adds new development origins for deployment environments
- Fixes runtime errors related to translation caching

## Code changes

**Navigation positioning:**
- Modified `Navigation.tsx` to change language button positioning from negative translate (left) to positive translate (right) on desktop only

**Translation system improvements:**
- Created new `ctaOverrides.ts` module with manual translations for "See All Villa Types" and "View Brochure" buttons across 12 languages
- Updated translation caching system with versioning to prevent stale cache issues
- Modified `PropertiesSection.tsx` and `BrochureButton.tsx` to use override translations
- Enhanced `useTranslation.tsx` with cache versioning and CTA override integration
- Updated translation API route to prioritize manual overrides over automatic translations

**Configuration updates:**
- Added new Fly.dev deployment origins to `next.config.js`
- Updated base translation strings to include new CTA text keys

**Bug fixes:**
- Implemented proper cache invalidation when translation schema changes
- Fixed potential runtime errors from stale translation cache entries

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e5fdd11587534640ab84596faaf47bce/vibe-lab)

👀 [Preview Link](https://e5fdd11587534640ab84596faaf47bce-vibe-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5fdd11587534640ab84596faaf47bce</projectId>-->
<!--<branchName>vibe-lab</branchName>-->